### PR TITLE
fix: skip commitizen check on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   commitizen:
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Checklist

- [ ] Commit messages are meaningful and describe what changed and why
- [ ] Each commit is atomic and self-contained
- [ ] New functionality is covered by automated tests
- [ ] CI pipeline is green
- [ ] Branch is rebased on main before merging
