### PR TITLE
test: cover ValueError branches in gpx and tcx numeric parsers

### DIFF
--- a/tests/parsers/test_gpx.py
+++ b/tests/parsers/test_gpx.py
@@ -200,6 +200,7 @@ class TestGpxParserUnit:
           <gpxtpx:TrackPointExtension>
             <gpxtpx:hr>bad</gpxtpx:hr>
             <gpxtpx:cad>bad</gpxtpx:cad>
+            <gpxtpx:atemp>bad</gpxtpx:atemp>
           </gpxtpx:TrackPointExtension>
         </extensions>
       </trkpt>
@@ -211,6 +212,7 @@ class TestGpxParserUnit:
         pt = result.track[0]
         assert pt.heart_rate is None
         assert pt.cadence is None
+        assert pt.temperature is None
 
     def test_trackpoint_without_time_skipped(self, parser: GpxParser) -> None:
         gpx = """\

--- a/tests/parsers/test_tcx.py
+++ b/tests/parsers/test_tcx.py
@@ -234,6 +234,28 @@ class TestTcxParserUnit:
         assert pt.heart_rate is None
         assert pt.cadence is None
 
+    def test_bad_float_field_yields_none(self, parser: TcxParser) -> None:
+        tcx = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities>
+    <Activity Sport="Biking">
+      <Id>2026-01-01T08:00:00.000Z</Id>
+      <Lap>
+        <Track>
+          <Trackpoint>
+            <Time>2026-01-01T08:00:00.000Z</Time>
+            <AltitudeMeters>bad</AltitudeMeters>
+          </Trackpoint>
+        </Track>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>"""
+        result = parser.parse(tcx.encode())
+
+        assert result.track[0].altitude is None
+
     def test_trackpoint_with_invalid_time_skipped(self, parser: TcxParser) -> None:
         tcx = """\
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Checklist

- [ ] Commit messages are meaningful and describe what changed and why
- [ ] Each commit is atomic and self-contained
- [ ] New functionality is covered by automated tests
- [ ] CI pipeline is green
- [ ] Branch is rebased on main before merging
