### PR TITLE
feat(wellness): add wellness data sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ poetry run trainings-sync \
 | `--creds-keepass PATH` | KeePass database (.kdbx) instead of a JSON file. Master password is read from `KEEPASS_PASSWORD` env var, or prompted from stdin. Not supported with Strava sources or destinations. |
 | `--start DATE`         | Start date (YYYY-MM-DD). Overrides the value in config. Defaults to `2000-01-01` if not set anywhere.                                                                     |
 | `--end DATE`           | End date (YYYY-MM-DD). Overrides the value in config. Defaults to today.                                                                                                  |
-| `--force`              | Re-download activities even if already cached.                                                                                                                            |
+| `--force`              | Re-download activities even if already cached. Also re-downloads all wellness data.                                                                                       |
+| `--skip-wellness`      | Skip wellness data sync (only sync training activities).                                                                                                                  |
 
 If a sync run is interrupted, simply run the same command again. Already downloaded activities are stored in the cache (`cache_dir` in config) and will not be re-downloaded.
 
@@ -211,6 +212,41 @@ request:
 
 When a limit is reached, the sync automatically pauses and resumes after the window resets. Your app's
 current limits are shown at [strava.com/settings/api](https://www.strava.com/settings/api).
+
+## Wellness data sync
+
+In addition to training activities, the tool automatically syncs wellness data from each configured service to local folder destinations. This happens on every run by default (use `--skip-wellness` to disable).
+
+### What is synced
+
+**From Garmin Connect** (stored under `{folder}/wellness/`):
+
+| Category | Data types |
+|---|---|
+| Sleep & recovery | `sleep`, `hrv`, `body_battery`, `body_battery_events`, `training_readiness`, `morning_training_readiness` |
+| Heart & blood | `heart_rates`, `resting_hr`, `spo2`, `blood_pressure` |
+| Stress | `stress_daily`, `all_day_stress`, `weekly_stress` |
+| Body composition | `body_composition`, `weigh_ins`, `daily_weigh_ins` |
+| Activity | `steps_daily`, `daily_steps_range`, `weekly_steps`, `floors`, `intensity_minutes`, `weekly_intensity_minutes`, `hydration`, `lifestyle_logging` |
+| Performance | `vo2max`, `lactate_threshold`, `training_status`, `endurance_score`, `running_tolerance`, `race_predictions`, `fitness_age`, `hill_score` |
+| Miscellaneous | `personal_records`, `user_summary`, `stats` |
+
+**From Strava** (snapshot data): `athlete_stats`, `athlete_zones`
+
+### Storage layout
+
+Each data type is stored as JSON files under:
+```
+{local_folder}/wellness/{data_type}/{YYYY-MM-DD}.json   # daily data
+{local_folder}/wellness/{data_type}/{start}_{end}.json  # range data
+{local_folder}/wellness/{data_type}/snapshot.json       # snapshot data
+```
+
+Wellness data is also cached in `{cache_dir}/wellness/` using the same layout. Re-running the tool only fetches dates not yet in the cache. Use `--force` to invalidate the cache and re-download everything.
+
+### Writable data types
+
+For Garmin, the following types support both reading and writing: `body_composition`, `weigh_ins`, `daily_weigh_ins`, `blood_pressure`, `hydration`. Writing back to Garmin from a local folder is not yet automated but the connectors implement the full interface.
 
 ## Contributing
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -178,6 +178,8 @@ async def _run_wellness(
         wellness_connectors = await build_wellness_connectors(
             config, provider, tracker, connectors
         )
+        for wc in wellness_connectors.values():
+            await wc.login()
         wellness_orchestrator = WellnessOrchestrator(
             wellness_connectors, wellness_cache, tracker
         )
@@ -271,10 +273,10 @@ async def _run_sync(
                     t.cancel()
             await asyncio.gather(*login_tasks.values(), return_exceptions=True)
 
-    if not getattr(args, "skip_wellness", False):
-        await _run_wellness(
-            args, config, sync_logger, tracker, provider, connectors, start, end
-        )
+        if not getattr(args, "skip_wellness", False):
+            await _run_wellness(
+                args, config, sync_logger, tracker, provider, connectors, start, end
+            )
 
     print(f"Sync finished: {_current_run_timestamp()}")
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -92,6 +92,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="re-download activities even if already cached",
     )
+    parser.add_argument(
+        "--skip-wellness",
+        action="store_true",
+        help="skip wellness data sync",
+    )
     creds_group = parser.add_mutually_exclusive_group(required=False)
     creds_group.add_argument(
         "--creds-json",
@@ -152,6 +157,33 @@ def _validate(
             file=sys.stderr,
         )
         sys.exit(1)
+
+
+async def _run_wellness(
+    args: argparse.Namespace,
+    config: AppConfig,
+    sync_logger: SyncLogger,
+    tracker: TaskTracker,
+    provider: CredentialProvider,
+    connectors: dict,
+    start: date,
+    end: date,
+) -> None:
+    from app.core.connector_factory import build_wellness_connectors
+    from app.core.wellness_cache import WellnessCache
+    from app.core.wellness_orchestrator import WellnessOrchestrator
+
+    try:
+        wellness_cache = WellnessCache(config.cache_dir)
+        wellness_connectors = await build_wellness_connectors(
+            config, provider, tracker, connectors
+        )
+        wellness_orchestrator = WellnessOrchestrator(
+            wellness_connectors, wellness_cache, tracker
+        )
+        await wellness_orchestrator.run(start, end, force=args.force)
+    except Exception as exc:
+        sync_logger.warning(f"[wellness] sync failed: {exc}")
 
 
 async def _run_sync(
@@ -238,6 +270,11 @@ async def _run_sync(
                 if not t.done():
                     t.cancel()
             await asyncio.gather(*login_tasks.values(), return_exceptions=True)
+
+    if not getattr(args, "skip_wellness", False):
+        await _run_wellness(
+            args, config, sync_logger, tracker, provider, connectors, start, end
+        )
 
     print(f"Sync finished: {_current_run_timestamp()}")
 

--- a/app/connectors/garmin_wellness.py
+++ b/app/connectors/garmin_wellness.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+from garminconnect import Garmin  # type: ignore[import-untyped]
+
+from app.connectors.base import _run_with_timeout
+from app.connectors.wellness_base import (
+    AccessLevel,
+    DataTypeSpec,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.connectors.wellness_capabilities import GARMIN_CAPABILITIES
+from app.credentials.base import Credentials
+from app.tracking.tracker import TaskTracker
+
+if TYPE_CHECKING:
+    from app.connectors.garmin import GarminConnector
+
+_UNHANDLED = object()
+
+_DAILY_FETCH: dict[WellnessDataType, Callable[[Garmin, str], Any]] = {
+    WellnessDataType.SLEEP: lambda c, d: c.get_sleep_data(d),
+    WellnessDataType.HRV: lambda c, d: c.get_hrv_data(d),
+    WellnessDataType.HEART_RATES: lambda c, d: c.get_heart_rates(d),
+    WellnessDataType.RESTING_HR: lambda c, d: c.get_rhr_day(d),
+    WellnessDataType.BODY_BATTERY_EVENTS: lambda c, d: c.get_body_battery_events(d),
+    WellnessDataType.STRESS_DAILY: lambda c, d: c.get_stress_data(d),
+    WellnessDataType.ALL_DAY_STRESS: lambda c, d: c.get_all_day_stress(d),
+    WellnessDataType.SPO2: lambda c, d: c.get_spo2_data(d),
+    WellnessDataType.RESPIRATION: lambda c, d: c.get_respiration_data(d),
+    WellnessDataType.STEPS_DAILY: lambda c, d: c.get_steps_data(d),
+    WellnessDataType.FLOORS: lambda c, d: c.get_floors(d),
+    WellnessDataType.INTENSITY_MINUTES: lambda c, d: c.get_intensity_minutes_data(d),
+    WellnessDataType.VO2MAX: lambda c, d: c.get_max_metrics(d),
+    WellnessDataType.TRAINING_READINESS: lambda c, d: c.get_training_readiness(d),
+    WellnessDataType.MORNING_TRAINING_READINESS: lambda c, d: (
+        c.get_morning_training_readiness(d)
+    ),
+    WellnessDataType.TRAINING_STATUS: lambda c, d: c.get_training_status(d),
+    WellnessDataType.FITNESS_AGE: lambda c, d: c.get_fitnessage_data(d),
+    WellnessDataType.DAILY_WEIGH_INS: lambda c, d: c.get_daily_weigh_ins(d),
+    WellnessDataType.HYDRATION: lambda c, d: c.get_hydration_data(d),
+    WellnessDataType.USER_SUMMARY: lambda c, d: c.get_user_summary(d),
+    WellnessDataType.STATS: lambda c, d: c.get_stats(d),
+    WellnessDataType.LIFESTYLE_LOGGING: lambda c, d: c.get_lifestyle_logging_data(d),
+}
+
+
+def _normalize_result(result: Any) -> dict | None:
+    if result is None:
+        return None
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, list):
+        return {"items": result}
+    return {"value": result}
+
+
+class GarminWellnessConnector(WellnessConnector):
+    def __init__(
+        self,
+        connector_id: str,
+        credentials: Credentials,
+        tracker: TaskTracker,
+        client: Garmin | None = None,
+    ) -> None:
+        super().__init__(tracker)
+        self._connector_id = connector_id
+        self._credentials = credentials
+        self._client: Garmin | None = client
+
+    @classmethod
+    def from_garmin_connector(
+        cls,
+        connector_id: str,
+        garmin_connector: GarminConnector,
+        tracker: TaskTracker,
+    ) -> GarminWellnessConnector:
+        instance = cls(
+            connector_id=connector_id,
+            credentials=garmin_connector._credentials,
+            tracker=tracker,
+            client=garmin_connector._client,
+        )
+        return instance
+
+    @property
+    def connector_id(self) -> str:
+        return self._connector_id
+
+    def _require_client(self) -> Garmin:
+        if self._client is None:
+            raise RuntimeError("Not logged in - call login() first")
+        return self._client
+
+    async def login(self) -> None:
+        if self._client is not None:
+            return
+        task_name = await self._tracker.add_task(
+            f"Garmin wellness ({self._credentials.login}): login", total=1
+        )
+        log = self._tracker.sync_logger
+        client = Garmin(
+            email=self._credentials.login,
+            password=self._credentials.password,
+        )
+        try:
+            await _run_with_timeout(asyncio.to_thread(client.login))
+        except BaseException as exc:
+            await self._tracker.fail(task_name, error=f"Login failed: {exc}")
+            raise
+        if log:
+            log.info(f"[garmin-wellness] Login: success ({self._credentials.login})")
+        self._client = client
+        await self._tracker.advance(task_name)
+        await self._tracker.finish(task_name)
+
+    def supported_types(self) -> dict[WellnessDataType, DataTypeSpec]:
+        return GARMIN_CAPABILITIES
+
+    async def fetch_daily(self, data_type: WellnessDataType, d: date) -> dict | None:
+        fetch_fn = _DAILY_FETCH.get(data_type)
+        if fetch_fn is None:
+            self._log_unsupported("fetch_daily", data_type)
+            return None
+        client = self._require_client()
+        log = self._tracker.sync_logger
+        date_str = d.isoformat()
+        try:
+            result = await _run_with_timeout(
+                asyncio.to_thread(fetch_fn, client, date_str)
+            )
+            return _normalize_result(result)
+        except Exception as exc:
+            if log:
+                log.debug(
+                    f"[garmin-wellness] {self._connector_id}:"
+                    f" fetch_daily({data_type.value}, {date_str}) failed: {exc}"
+                )
+            return None
+
+    async def fetch_range(
+        self, data_type: WellnessDataType, start: date, end: date
+    ) -> dict | None:
+        client = self._require_client()
+        log = self._tracker.sync_logger
+        start_str = start.isoformat()
+        end_str = end.isoformat()
+        weeks = max(1, (end - start).days // 7 + 1)
+        try:
+            result = await self._fetch_range_for_type(
+                client, data_type, start_str, end_str, weeks
+            )
+            return _normalize_result(result)
+        except Exception as exc:
+            if log:
+                log.debug(
+                    f"[garmin-wellness] {self._connector_id}:"
+                    f" fetch_range({data_type.value},"
+                    f" {start_str}, {end_str}) failed: {exc}"
+                )
+            return None
+
+    async def _fetch_range_for_type(
+        self,
+        client: Garmin,
+        data_type: WellnessDataType,
+        start_str: str,
+        end_str: str,
+        weeks: int,
+    ) -> Any:
+        result = await self._fetch_range_body_metrics(
+            client, data_type, start_str, end_str
+        )
+        if result is not _UNHANDLED:
+            return result
+        result = await self._fetch_range_activity_metrics(
+            client, data_type, start_str, end_str, weeks
+        )
+        if result is not _UNHANDLED:
+            return result
+        self._log_unsupported("fetch_range", data_type)
+        return None
+
+    async def _fetch_range_body_metrics(
+        self,
+        client: Garmin,
+        data_type: WellnessDataType,
+        start_str: str,
+        end_str: str,
+    ) -> Any:
+        if data_type == WellnessDataType.BODY_BATTERY:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_body_battery, start_str, end_str)
+            )
+        if data_type == WellnessDataType.BODY_COMPOSITION:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_body_composition, start_str, end_str)
+            )
+        if data_type == WellnessDataType.WEIGH_INS:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_weigh_ins, start_str, end_str)
+            )
+        if data_type == WellnessDataType.BLOOD_PRESSURE:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_blood_pressure, start_str, end_str)
+            )
+        if data_type == WellnessDataType.DAILY_STEPS_RANGE:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_daily_steps, start_str, end_str)
+            )
+        if data_type == WellnessDataType.LACTATE_THRESHOLD:
+            return await _run_with_timeout(
+                asyncio.to_thread(
+                    client.get_lactate_threshold,
+                    start_date=start_str,
+                    end_date=end_str,
+                )
+            )
+        return _UNHANDLED
+
+    async def _fetch_range_activity_metrics(
+        self,
+        client: Garmin,
+        data_type: WellnessDataType,
+        start_str: str,
+        end_str: str,
+        weeks: int,
+    ) -> Any:
+        if data_type == WellnessDataType.WEEKLY_STEPS:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_weekly_steps, end_str, weeks)
+            )
+        if data_type == WellnessDataType.WEEKLY_STRESS:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_weekly_stress, end_str, weeks)
+            )
+        if data_type == WellnessDataType.WEEKLY_INTENSITY_MINUTES:
+            return await _run_with_timeout(
+                asyncio.to_thread(
+                    client.get_weekly_intensity_minutes, start_str, end_str
+                )
+            )
+        if data_type == WellnessDataType.ENDURANCE_SCORE:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_endurance_score, start_str, end_str)
+            )
+        if data_type == WellnessDataType.RUNNING_TOLERANCE:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_running_tolerance, start_str, end_str)
+            )
+        if data_type == WellnessDataType.RACE_PREDICTIONS:
+            return await _run_with_timeout(
+                asyncio.to_thread(
+                    client.get_race_predictions,
+                    startdate=start_str,
+                    enddate=end_str,
+                )
+            )
+        if data_type == WellnessDataType.HILL_SCORE:
+            return await _run_with_timeout(
+                asyncio.to_thread(client.get_hill_score, start_str, end_str)
+            )
+        return _UNHANDLED
+
+    async def fetch_snapshot(self, data_type: WellnessDataType) -> dict | None:
+        client = self._require_client()
+        log = self._tracker.sync_logger
+        if data_type != WellnessDataType.PERSONAL_RECORDS:
+            self._log_unsupported("fetch_snapshot", data_type)
+            return None
+        try:
+            result = await _run_with_timeout(
+                asyncio.to_thread(client.get_personal_record)
+            )
+            return _normalize_result(result)
+        except Exception as exc:
+            if log:
+                log.debug(
+                    f"[garmin-wellness] {self._connector_id}:"
+                    f" fetch_snapshot({data_type.value}) failed: {exc}"
+                )
+            return None
+
+    async def push_record(
+        self, data_type: WellnessDataType, d: date | None, data: dict
+    ) -> None:
+        spec = GARMIN_CAPABILITIES.get(data_type)
+        if spec is None or spec.access != AccessLevel.READ_WRITE:
+            self._log_unsupported("push_record", data_type)
+            return
+        client = self._require_client()
+        log = self._tracker.sync_logger
+        try:
+            await self._push_for_type(client, data_type, d, data)
+        except Exception as exc:
+            if log:
+                log.warning(
+                    f"[garmin-wellness] {self._connector_id}:"
+                    f" push_record({data_type.value}) failed: {exc}"
+                )
+
+    async def _push_for_type(
+        self,
+        client: Garmin,
+        data_type: WellnessDataType,
+        d: date | None,
+        data: dict,
+    ) -> None:
+        if data_type == WellnessDataType.DAILY_WEIGH_INS:
+            weight = data.get("weight") or data.get("value")
+            if weight is not None:
+                await _run_with_timeout(
+                    asyncio.to_thread(client.add_weigh_in, float(weight))
+                )
+            return
+        if data_type == WellnessDataType.HYDRATION:
+            value_ml = data.get("value_in_ml") or data.get("value")
+            cdate = d.isoformat() if d is not None else None
+            if value_ml is not None:
+                await _run_with_timeout(
+                    asyncio.to_thread(
+                        client.add_hydration_data,
+                        float(value_ml),
+                        cdate=cdate,
+                    )
+                )
+            return
+        if data_type in (WellnessDataType.WEIGH_INS, WellnessDataType.BODY_COMPOSITION):
+            weight = data.get("weight") or data.get("value")
+            timestamp = data.get("timestamp")
+            if weight is not None:
+                await _run_with_timeout(
+                    asyncio.to_thread(
+                        client.add_body_composition,
+                        timestamp,
+                        float(weight),
+                    )
+                )
+            return
+        if data_type == WellnessDataType.BLOOD_PRESSURE:
+            systolic = data.get("systolic")
+            diastolic = data.get("diastolic")
+            pulse = data.get("pulse", 0)
+            if systolic is not None and diastolic is not None:
+                await _run_with_timeout(
+                    asyncio.to_thread(
+                        client.set_blood_pressure,
+                        int(systolic),
+                        int(diastolic),
+                        int(pulse),
+                    )
+                )
+            return
+        self._log_unsupported("push_record", data_type)

--- a/app/connectors/local_folder_wellness.py
+++ b/app/connectors/local_folder_wellness.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from app.connectors.wellness_base import (
+    DataTypeSpec,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.connectors.wellness_capabilities import LOCAL_FOLDER_CAPABILITIES
+
+
+class LocalFolderWellnessConnector(WellnessConnector):
+    def __init__(
+        self,
+        connector_id: str,
+        folder: Path,
+        tracker: object,
+    ) -> None:
+
+        super().__init__(tracker)  # type: ignore[arg-type]
+        self._connector_id = connector_id
+        self._folder = folder
+
+    @property
+    def connector_id(self) -> str:
+        return self._connector_id
+
+    async def login(self) -> None:
+        from app.tracking.tracker import TaskTracker
+
+        tracker: TaskTracker = self._tracker  # type: ignore[assignment]
+        task_name = await tracker.add_task(
+            f"Local folder wellness ({self._folder}): connect", total=1
+        )
+        try:
+            if not self._folder.is_dir():
+                raise FileNotFoundError(f"Folder not found: {self._folder}")
+            await tracker.advance(task_name)
+            await tracker.finish(task_name)
+        except BaseException as exc:
+            await tracker.fail(task_name, error=str(exc))
+            raise
+
+    def supported_types(self) -> dict[WellnessDataType, DataTypeSpec]:
+        return LOCAL_FOLDER_CAPABILITIES
+
+    async def fetch_daily(self, data_type: WellnessDataType, d: date) -> dict | None:
+        p = self._data_path(data_type, d.isoformat())
+        if not p.is_file():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    async def fetch_range(
+        self, data_type: WellnessDataType, start: date, end: date
+    ) -> dict | None:
+        key = f"{start}_{end}"
+        p = self._data_path(data_type, key)
+        if not p.is_file():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    async def fetch_snapshot(self, data_type: WellnessDataType) -> dict | None:
+        p = self._data_path(data_type, "snapshot")
+        if not p.is_file():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    async def push_record(
+        self, data_type: WellnessDataType, d: date | None, data: dict
+    ) -> None:
+        date_key = d.isoformat() if d is not None else "snapshot"
+        p = self._data_path(data_type, date_key)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(p)
+
+    def _data_path(self, data_type: WellnessDataType, date_key: str) -> Path:
+        return self._folder / "wellness" / data_type.value / f"{date_key}.json"

--- a/app/connectors/strava_wellness.py
+++ b/app/connectors/strava_wellness.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from stravalib import Client as StravaClient
+
+from app.connectors.wellness_base import (
+    DataTypeSpec,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.connectors.wellness_capabilities import STRAVA_CAPABILITIES
+from app.tracking.tracker import TaskTracker
+
+
+class StravaWellnessConnector(WellnessConnector):
+    def __init__(
+        self,
+        connector_id: str,
+        strava_client: StravaClient,
+        tracker: TaskTracker,
+    ) -> None:
+        super().__init__(tracker)
+        self._connector_id = connector_id
+        self._client = strava_client
+
+    @property
+    def connector_id(self) -> str:
+        return self._connector_id
+
+    async def login(self) -> None:
+        task_name = await self._tracker.add_task(
+            f"Strava wellness ({self._connector_id}): connect", total=1
+        )
+        await self._tracker.advance(task_name)
+        await self._tracker.finish(task_name)
+
+    def supported_types(self) -> dict[WellnessDataType, DataTypeSpec]:
+        return STRAVA_CAPABILITIES
+
+    async def fetch_snapshot(self, data_type: WellnessDataType) -> dict | None:
+        if data_type == WellnessDataType.ATHLETE_STATS:
+            return await self._fetch_athlete_stats()
+        if data_type == WellnessDataType.ATHLETE_ZONES:
+            return await self._fetch_athlete_zones()
+        self._log_unsupported("fetch_snapshot", data_type)
+        return None
+
+    async def _fetch_athlete_stats(self) -> dict | None:
+        log = self._tracker.sync_logger
+        try:
+            athlete = await asyncio.to_thread(self._client.get_athlete)
+            athlete_id = athlete.id
+            result = await asyncio.to_thread(self._client.get_athlete_stats, athlete_id)
+            return json.loads(result.model_dump_json())
+        except Exception as exc:
+            if log:
+                log.debug(
+                    f"[strava-wellness] {self._connector_id}:"
+                    f" fetch_snapshot(athlete_stats) failed: {exc}"
+                )
+            return None
+
+    async def _fetch_athlete_zones(self) -> dict | None:
+        log = self._tracker.sync_logger
+        try:
+            result = await asyncio.to_thread(self._client.get_athlete_zones)
+            return json.loads(result.model_dump_json())
+        except Exception as exc:
+            if log:
+                log.debug(
+                    f"[strava-wellness] {self._connector_id}:"
+                    f" fetch_snapshot(athlete_zones) failed: {exc}"
+                )
+            return None

--- a/app/connectors/wellness_base.py
+++ b/app/connectors/wellness_base.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+from app.tracking.tracker import TaskTracker
+
+
+class WellnessDataType(str, Enum):
+    SLEEP = "sleep"
+    HRV = "hrv"
+    HEART_RATES = "heart_rates"
+    RESTING_HR = "resting_hr"
+    BODY_BATTERY_EVENTS = "body_battery_events"
+    STRESS_DAILY = "stress_daily"
+    ALL_DAY_STRESS = "all_day_stress"
+    SPO2 = "spo2"
+    RESPIRATION = "respiration"
+    STEPS_DAILY = "steps_daily"
+    FLOORS = "floors"
+    INTENSITY_MINUTES = "intensity_minutes"
+    VO2MAX = "vo2max"
+    TRAINING_READINESS = "training_readiness"
+    MORNING_TRAINING_READINESS = "morning_training_readiness"
+    TRAINING_STATUS = "training_status"
+    FITNESS_AGE = "fitness_age"
+    DAILY_WEIGH_INS = "daily_weigh_ins"
+    HYDRATION = "hydration"
+    USER_SUMMARY = "user_summary"
+    STATS = "stats"
+    LIFESTYLE_LOGGING = "lifestyle_logging"
+    BODY_BATTERY = "body_battery"
+    BODY_COMPOSITION = "body_composition"
+    WEIGH_INS = "weigh_ins"
+    BLOOD_PRESSURE = "blood_pressure"
+    DAILY_STEPS_RANGE = "daily_steps_range"
+    WEEKLY_STEPS = "weekly_steps"
+    WEEKLY_STRESS = "weekly_stress"
+    WEEKLY_INTENSITY_MINUTES = "weekly_intensity_minutes"
+    LACTATE_THRESHOLD = "lactate_threshold"
+    ENDURANCE_SCORE = "endurance_score"
+    RUNNING_TOLERANCE = "running_tolerance"
+    RACE_PREDICTIONS = "race_predictions"
+    HILL_SCORE = "hill_score"
+    PERSONAL_RECORDS = "personal_records"
+    ATHLETE_STATS = "athlete_stats"
+    ATHLETE_ZONES = "athlete_zones"
+
+
+class TimeModel(str, Enum):
+    DAILY = "daily"
+    RANGE = "range"
+    SNAPSHOT = "snapshot"
+
+
+class AccessLevel(str, Enum):
+    READ = "read"
+    READ_WRITE = "read_write"
+
+
+@dataclass(frozen=True)
+class DataTypeSpec:
+    time_model: TimeModel
+    access: AccessLevel
+
+
+class WellnessConnector(ABC):
+    def __init__(self, tracker: TaskTracker) -> None:
+        self._tracker = tracker
+
+    @property
+    @abstractmethod
+    def connector_id(self) -> str: ...
+
+    @abstractmethod
+    async def login(self) -> None: ...
+
+    def supported_types(self) -> dict[WellnessDataType, DataTypeSpec]:
+        return {}
+
+    async def fetch_daily(self, data_type: WellnessDataType, d: date) -> dict | None:
+        self._log_unsupported("fetch_daily", data_type)
+        return None
+
+    async def fetch_range(
+        self, data_type: WellnessDataType, start: date, end: date
+    ) -> dict | None:
+        self._log_unsupported("fetch_range", data_type)
+        return None
+
+    async def fetch_snapshot(self, data_type: WellnessDataType) -> dict | None:
+        self._log_unsupported("fetch_snapshot", data_type)
+        return None
+
+    async def push_record(
+        self, data_type: WellnessDataType, d: date | None, data: dict
+    ) -> None:
+        self._log_unsupported("push_record", data_type)
+
+    def _log_unsupported(self, method: str, data_type: WellnessDataType) -> None:
+        log = self._tracker.sync_logger
+        if log:
+            log.debug(
+                f"[wellness] {self.connector_id}: {method}({data_type.value})"
+                " not supported - skipped"
+            )
+
+    async def _find_earliest_supported_date(
+        self,
+        probe_fn: Callable[[date, date], Awaitable[dict | None]],
+        lo: date,
+        hi: date,
+    ) -> date | None:
+        """Binary search for the earliest date for which probe_fn(d, hi) succeeds.
+
+        Returns None if even hi itself fails.
+        """
+        try:
+            result = await probe_fn(hi, hi)
+            if result is None:
+                return None
+        except Exception:
+            return None
+
+        best = hi
+        while lo < hi:
+            mid_ord = (lo.toordinal() + hi.toordinal()) // 2
+            mid = date.fromordinal(mid_ord)
+            try:
+                result = await probe_fn(mid, hi)
+                success = result is not None
+            except Exception:
+                success = False
+            if success:
+                best = mid
+                hi = mid
+            else:
+                from datetime import timedelta
+
+                lo = mid + timedelta(days=1)
+        return best

--- a/app/connectors/wellness_base.py
+++ b/app/connectors/wellness_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from enum import Enum
 
 from app.tracking.tracker import TaskTracker
@@ -138,7 +138,5 @@ class WellnessConnector(ABC):
                 best = mid
                 hi = mid
             else:
-                from datetime import timedelta
-
                 lo = mid + timedelta(days=1)
         return best

--- a/app/connectors/wellness_capabilities.py
+++ b/app/connectors/wellness_capabilities.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from app.connectors.wellness_base import (
+    AccessLevel,
+    DataTypeSpec,
+    TimeModel,
+    WellnessDataType,
+)
+
+GARMIN_CAPABILITIES: dict[WellnessDataType, DataTypeSpec] = {
+    WellnessDataType.SLEEP: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.HRV: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.HEART_RATES: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.RESTING_HR: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.BODY_BATTERY_EVENTS: DataTypeSpec(
+        TimeModel.DAILY, AccessLevel.READ
+    ),
+    WellnessDataType.STRESS_DAILY: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.ALL_DAY_STRESS: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.SPO2: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.RESPIRATION: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.STEPS_DAILY: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.FLOORS: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.INTENSITY_MINUTES: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.VO2MAX: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.TRAINING_READINESS: DataTypeSpec(
+        TimeModel.DAILY, AccessLevel.READ
+    ),
+    WellnessDataType.MORNING_TRAINING_READINESS: DataTypeSpec(
+        TimeModel.DAILY, AccessLevel.READ
+    ),
+    WellnessDataType.TRAINING_STATUS: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.FITNESS_AGE: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.USER_SUMMARY: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.STATS: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.LIFESTYLE_LOGGING: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ),
+    WellnessDataType.DAILY_WEIGH_INS: DataTypeSpec(
+        TimeModel.DAILY, AccessLevel.READ_WRITE
+    ),
+    WellnessDataType.HYDRATION: DataTypeSpec(TimeModel.DAILY, AccessLevel.READ_WRITE),
+    WellnessDataType.BODY_BATTERY: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.DAILY_STEPS_RANGE: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.WEEKLY_STEPS: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.WEEKLY_STRESS: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.WEEKLY_INTENSITY_MINUTES: DataTypeSpec(
+        TimeModel.RANGE, AccessLevel.READ
+    ),
+    WellnessDataType.LACTATE_THRESHOLD: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.ENDURANCE_SCORE: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.RUNNING_TOLERANCE: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.RACE_PREDICTIONS: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.HILL_SCORE: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ),
+    WellnessDataType.BODY_COMPOSITION: DataTypeSpec(
+        TimeModel.RANGE, AccessLevel.READ_WRITE
+    ),
+    WellnessDataType.WEIGH_INS: DataTypeSpec(TimeModel.RANGE, AccessLevel.READ_WRITE),
+    WellnessDataType.BLOOD_PRESSURE: DataTypeSpec(
+        TimeModel.RANGE, AccessLevel.READ_WRITE
+    ),
+    WellnessDataType.PERSONAL_RECORDS: DataTypeSpec(
+        TimeModel.SNAPSHOT, AccessLevel.READ
+    ),
+}
+
+STRAVA_CAPABILITIES: dict[WellnessDataType, DataTypeSpec] = {
+    WellnessDataType.ATHLETE_STATS: DataTypeSpec(TimeModel.SNAPSHOT, AccessLevel.READ),
+    WellnessDataType.ATHLETE_ZONES: DataTypeSpec(TimeModel.SNAPSHOT, AccessLevel.READ),
+}
+
+LOCAL_FOLDER_CAPABILITIES: dict[WellnessDataType, DataTypeSpec] = {
+    dt: DataTypeSpec(spec.time_model, AccessLevel.READ_WRITE)
+    for dt, spec in {**GARMIN_CAPABILITIES, **STRAVA_CAPABILITIES}.items()
+}

--- a/app/core/connector_factory.py
+++ b/app/core/connector_factory.py
@@ -6,9 +6,11 @@ from app.connectors.base import ServiceConnector
 from app.connectors.garmin import GarminConnector
 from app.connectors.local_folder import LocalFolderConnector
 from app.connectors.strava import StravaConnector
+from app.connectors.wellness_base import WellnessConnector
 from app.core.config import (
     AppConfig,
     GarminConnectorConfig,
+    LocalFolderConnectorConfig,
     StravaConnectorConfig,
     SyncGroupConfig,
 )
@@ -66,6 +68,53 @@ async def build_connectors(
             connector = LocalFolderConnector(folder=cfg.folder, tracker=tracker)
         result[cfg.id] = connector
 
+    return result
+
+
+async def build_wellness_connectors(
+    config: AppConfig,
+    provider: CredentialProvider,
+    tracker: TaskTracker,
+    activity_connectors: dict[str, ServiceConnector],
+) -> dict[str, WellnessConnector]:
+    from app.connectors.garmin_wellness import GarminWellnessConnector
+    from app.connectors.local_folder_wellness import LocalFolderWellnessConnector
+    from app.connectors.strava_wellness import StravaWellnessConnector
+
+    result: dict[str, WellnessConnector] = {}
+    for cfg in config.connectors:
+        if isinstance(cfg, GarminConnectorConfig):
+            activity_conn = activity_connectors.get(cfg.id)
+            if isinstance(activity_conn, GarminConnector):
+                connector: WellnessConnector = (
+                    GarminWellnessConnector.from_garmin_connector(
+                        cfg.id, activity_conn, tracker
+                    )
+                )
+            else:
+                continue
+        elif isinstance(cfg, StravaConnectorConfig):
+            activity_conn = activity_connectors.get(cfg.id)
+            if (
+                isinstance(activity_conn, StravaConnector)
+                and activity_conn._client is not None
+            ):
+                connector = StravaWellnessConnector(
+                    connector_id=cfg.id,
+                    strava_client=activity_conn._client,
+                    tracker=tracker,
+                )
+            else:
+                continue
+        elif isinstance(cfg, LocalFolderConnectorConfig):
+            connector = LocalFolderWellnessConnector(
+                connector_id=cfg.id,
+                folder=cfg.folder,
+                tracker=tracker,
+            )
+        else:
+            continue
+        result[cfg.id] = connector
     return result
 
 

--- a/app/core/wellness_cache.py
+++ b/app/core/wellness_cache.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import date
+from pathlib import Path
+from typing import ClassVar
+
+from app.connectors.wellness_base import WellnessDataType
+
+
+class WellnessCache:
+    SNAPSHOT_KEY: ClassVar[str] = "snapshot"
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._dir = cache_dir / "wellness"
+
+    def has(
+        self, connector_id: str, data_type: WellnessDataType, date_key: str
+    ) -> bool:
+        return self._path(connector_id, data_type, date_key).is_file()
+
+    def read(
+        self, connector_id: str, data_type: WellnessDataType, date_key: str
+    ) -> dict | None:
+        p = self._path(connector_id, data_type, date_key)
+        if not p.is_file():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def write(
+        self,
+        connector_id: str,
+        data_type: WellnessDataType,
+        date_key: str,
+        data: dict,
+    ) -> None:
+        p = self._path(connector_id, data_type, date_key)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(p)
+
+    def invalidate(self, connector_id: str) -> None:
+        d = self._dir / connector_id
+        if d.is_dir():
+            shutil.rmtree(d)
+
+    def _path(
+        self, connector_id: str, data_type: WellnessDataType, date_key: str
+    ) -> Path:
+        return self._dir / connector_id / data_type.value / f"{date_key}.json"
+
+    @staticmethod
+    def range_key(start: date, end: date) -> str:
+        return f"{start}_{end}"
+
+    @staticmethod
+    def daily_key(d: date) -> str:
+        return d.isoformat()

--- a/app/core/wellness_orchestrator.py
+++ b/app/core/wellness_orchestrator.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+
+from app.connectors.local_folder_wellness import LocalFolderWellnessConnector
+from app.connectors.wellness_base import (
+    TimeModel,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.core.wellness_cache import WellnessCache
+from app.tracking.tracker import TaskTracker
+
+_MAX_CONCURRENT = 5
+
+
+class WellnessOrchestrator:
+    def __init__(
+        self,
+        connectors: dict[str, WellnessConnector],
+        cache: WellnessCache,
+        tracker: TaskTracker,
+    ) -> None:
+        self._connectors = connectors
+        self._cache = cache
+        self._tracker = tracker
+
+    async def run(self, start: date, end: date, *, force: bool = False) -> None:
+        sources = {
+            cid: c
+            for cid, c in self._connectors.items()
+            if not isinstance(c, LocalFolderWellnessConnector)
+        }
+        destinations = {
+            cid: c
+            for cid, c in self._connectors.items()
+            if isinstance(c, LocalFolderWellnessConnector)
+        }
+
+        dates = [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+        for src_id, source in sources.items():
+            if force:
+                self._cache.invalidate(src_id)
+            await self._download_from_source(source, src_id, dates, start, end)
+
+        for dest in destinations.values():
+            await self._upload_to_destination(dest, sources, dates, start, end)
+
+    async def _download_from_source(
+        self,
+        source: WellnessConnector,
+        connector_id: str,
+        dates: list[date],
+        start: date,
+        end: date,
+    ) -> None:
+        supported = source.supported_types()
+        if not supported:
+            return
+
+        daily_types = [
+            dt for dt, s in supported.items() if s.time_model == TimeModel.DAILY
+        ]
+        range_types = [
+            dt for dt, s in supported.items() if s.time_model == TimeModel.RANGE
+        ]
+        snapshot_types = [
+            dt for dt, s in supported.items() if s.time_model == TimeModel.SNAPSHOT
+        ]
+
+        total = len(daily_types) * len(dates) + len(range_types) + len(snapshot_types)
+        if total == 0:
+            return
+
+        task_name = await self._tracker.add_task(
+            f"Wellness download ({connector_id})", total=total
+        )
+        sem = asyncio.Semaphore(_MAX_CONCURRENT)
+
+        daily_coros = [
+            self._fetch_daily(source, connector_id, dt, d, task_name, sem)
+            for dt in daily_types
+            for d in dates
+        ]
+        range_coros = [
+            self._fetch_range(source, connector_id, dt, start, end, task_name, sem)
+            for dt in range_types
+        ]
+        snapshot_coros = [
+            self._fetch_snapshot(source, connector_id, dt, task_name, sem)
+            for dt in snapshot_types
+        ]
+
+        await asyncio.gather(*daily_coros, *range_coros, *snapshot_coros)
+        await self._tracker.finish(task_name)
+
+    async def _fetch_daily(
+        self,
+        source: WellnessConnector,
+        connector_id: str,
+        data_type: WellnessDataType,
+        d: date,
+        task_name: str,
+        sem: asyncio.Semaphore,
+    ) -> None:
+        key = WellnessCache.daily_key(d)
+        if self._cache.has(connector_id, data_type, key):
+            await self._tracker.advance(task_name)
+            return
+        async with sem:
+            result = await source.fetch_daily(data_type, d)
+        if result is not None:
+            self._cache.write(connector_id, data_type, key, result)
+        await self._tracker.advance(task_name)
+
+    async def _fetch_range(
+        self,
+        source: WellnessConnector,
+        connector_id: str,
+        data_type: WellnessDataType,
+        start: date,
+        end: date,
+        task_name: str,
+        sem: asyncio.Semaphore,
+    ) -> None:
+        key = WellnessCache.range_key(start, end)
+        if self._cache.has(connector_id, data_type, key):
+            await self._tracker.advance(task_name)
+            return
+        async with sem:
+            result = await source.fetch_range(data_type, start, end)
+        if result is not None:
+            self._cache.write(connector_id, data_type, key, result)
+        await self._tracker.advance(task_name)
+
+    async def _fetch_snapshot(
+        self,
+        source: WellnessConnector,
+        connector_id: str,
+        data_type: WellnessDataType,
+        task_name: str,
+        sem: asyncio.Semaphore,
+    ) -> None:
+        if self._cache.has(connector_id, data_type, WellnessCache.SNAPSHOT_KEY):
+            await self._tracker.advance(task_name)
+            return
+        async with sem:
+            result = await source.fetch_snapshot(data_type)
+        if result is not None:
+            self._cache.write(
+                connector_id, data_type, WellnessCache.SNAPSHOT_KEY, result
+            )
+        await self._tracker.advance(task_name)
+
+    async def _upload_to_destination(
+        self,
+        dest: WellnessConnector,
+        sources: dict[str, WellnessConnector],
+        dates: list[date],
+        start: date,
+        end: date,
+    ) -> None:
+        push_items = self._collect_push_items(dest, sources, dates, start, end)
+        if not push_items:
+            return
+
+        task_name = await self._tracker.add_task(
+            f"Wellness upload ({dest.connector_id})", total=len(push_items)
+        )
+        for push_dt, push_d, push_key, push_source_id in push_items:
+            data = self._cache.read(push_source_id, push_dt, push_key)
+            if data is not None:
+                await dest.push_record(push_dt, push_d, data)
+            await self._tracker.advance(task_name)
+        await self._tracker.finish(task_name)
+
+    def _collect_push_items(
+        self,
+        dest: WellnessConnector,
+        sources: dict[str, WellnessConnector],
+        dates: list[date],
+        start: date,
+        end: date,
+    ) -> list[tuple[WellnessDataType, date | None, str, str]]:
+        dest_supported = dest.supported_types()
+        if not dest_supported:
+            return []
+
+        items: list[tuple[WellnessDataType, date | None, str, str]] = []
+        for source_id, source in sources.items():
+            source_supported = source.supported_types()
+            for data_type in dest_supported:
+                if data_type not in source_supported:
+                    continue
+                items.extend(
+                    self._items_for_type(
+                        source_id,
+                        data_type,
+                        source_supported[data_type].time_model,
+                        dates,
+                        start,
+                        end,
+                    )
+                )
+        return items
+
+    def _items_for_type(
+        self,
+        source_id: str,
+        data_type: WellnessDataType,
+        time_model: TimeModel,
+        dates: list[date],
+        start: date,
+        end: date,
+    ) -> list[tuple[WellnessDataType, date | None, str, str]]:
+        items: list[tuple[WellnessDataType, date | None, str, str]] = []
+        if time_model == TimeModel.DAILY:
+            for d in dates:
+                key = WellnessCache.daily_key(d)
+                if self._cache.has(source_id, data_type, key):
+                    items.append((data_type, d, key, source_id))
+        elif time_model == TimeModel.RANGE:
+            key = WellnessCache.range_key(start, end)
+            if self._cache.has(source_id, data_type, key):
+                items.append((data_type, None, key, source_id))
+        elif time_model == TimeModel.SNAPSHOT:
+            key = WellnessCache.SNAPSHOT_KEY
+            if self._cache.has(source_id, data_type, key):
+                items.append((data_type, None, key, source_id))
+        return items

--- a/tests/connectors/test_garmin_wellness.py
+++ b/tests/connectors/test_garmin_wellness.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.connectors.garmin_wellness import GarminWellnessConnector, _normalize_result
+from app.connectors.wellness_base import WellnessDataType
+from app.connectors.wellness_capabilities import GARMIN_CAPABILITIES
+from app.credentials.base import Credentials
+from app.tracking.tracker import ProgressRenderer, Task, TaskTracker
+
+_CREDS = Credentials(login="user@example.com", password="secret")
+_START = date(2026, 1, 1)
+_END = date(2026, 1, 31)
+
+
+class _FakeRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None:
+        pass
+
+    def on_progress(self, task: Task) -> None:
+        pass
+
+    def on_task_done(self, task: Task) -> None:
+        pass
+
+    def on_task_failed(self, task: Task) -> None:
+        pass
+
+    def on_task_warning(self, task: Task, message: str) -> None:
+        pass
+
+    def on_total_updated(self, task: Task) -> None:
+        pass
+
+
+@pytest.fixture
+def tracker() -> TaskTracker:
+    return TaskTracker(_FakeRenderer())
+
+
+@pytest.fixture
+def fake_garmin() -> MagicMock:
+    client = MagicMock()
+    client.get_sleep_data.return_value = {"sleepData": []}
+    client.get_hrv_data.return_value = {"hrvData": []}
+    client.get_heart_rates.return_value = {"heartRateValues": []}
+    client.get_rhr_day.return_value = {"allMetrics": {}}
+    client.get_body_battery_events.return_value = []
+    client.get_stress_data.return_value = {"stressLevel": 30}
+    client.get_all_day_stress.return_value = {"stressValues": []}
+    client.get_spo2_data.return_value = {"spO2": []}
+    client.get_respiration_data.return_value = {"respiration": []}
+    client.get_steps_data.return_value = [{"steps": 5000}]
+    client.get_floors.return_value = {"floorCount": 3}
+    client.get_intensity_minutes_data.return_value = {"intensityMinutes": 45}
+    client.get_max_metrics.return_value = {"vo2MaxValue": 50}
+    client.get_training_readiness.return_value = {"score": 80}
+    client.get_morning_training_readiness.return_value = {"score": 75}
+    client.get_training_status.return_value = {"status": "productive"}
+    client.get_fitnessage_data.return_value = {"fitnessAge": 30}
+    client.get_daily_weigh_ins.return_value = {"dateWeightList": []}
+    client.get_hydration_data.return_value = {"hydrationMilliliters": 2000}
+    client.get_user_summary.return_value = {"totalSteps": 8000}
+    client.get_stats.return_value = {"totalKilocalories": 2500}
+    client.get_lifestyle_logging_data.return_value = {"loggingData": []}
+    client.get_body_battery.return_value = [{"charged": 80}]
+    client.get_body_composition.return_value = {"totalAverage": {"weight": 75}}
+    client.get_weigh_ins.return_value = {"dateWeightList": []}
+    client.get_blood_pressure.return_value = {"bloodPressure": []}
+    client.get_daily_steps.return_value = [{"steps": 8000}]
+    client.get_weekly_steps.return_value = [{"weeklySteps": 56000}]
+    client.get_weekly_stress.return_value = [{"weeklyStress": 25}]
+    client.get_weekly_intensity_minutes.return_value = [{"intensityMinutes": 150}]
+    client.get_lactate_threshold.return_value = {"lactate": {}}
+    client.get_endurance_score.return_value = {"score": 70}
+    client.get_running_tolerance.return_value = [{"tolerance": 80}]
+    client.get_race_predictions.return_value = {"predictions": []}
+    client.get_hill_score.return_value = {"score": 60}
+    client.get_personal_record.return_value = {"records": []}
+    client.add_weigh_in.return_value = {}
+    client.add_hydration_data.return_value = {}
+    client.add_body_composition.return_value = {}
+    client.set_blood_pressure.return_value = {}
+    return client
+
+
+@pytest.fixture
+def connector(tracker: TaskTracker, fake_garmin: MagicMock) -> GarminWellnessConnector:
+    return GarminWellnessConnector(
+        connector_id="garmin-main",
+        credentials=_CREDS,
+        tracker=tracker,
+        client=fake_garmin,
+    )
+
+
+class TestConnectorId:
+    def test_returns_configured_id(self, connector: GarminWellnessConnector) -> None:
+        assert connector.connector_id == "garmin-main"
+
+
+class TestSupportedTypes:
+    def test_returns_garmin_capabilities(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        assert connector.supported_types() == GARMIN_CAPABILITIES
+
+
+class TestLogin:
+    async def test_skips_login_when_client_exists(
+        self, connector: GarminWellnessConnector, tracker: TaskTracker
+    ) -> None:
+        await connector.login()
+        assert connector._client is not None
+
+    async def test_performs_login_when_no_client(self, tracker: TaskTracker) -> None:
+        c = GarminWellnessConnector("g", _CREDS, tracker)
+        mock_garmin = MagicMock()
+        with patch("app.connectors.garmin_wellness.Garmin", return_value=mock_garmin):
+            with patch(
+                "app.connectors.garmin_wellness._run_with_timeout",
+                new_callable=AsyncMock,
+            ) as mock_rw:
+                mock_rw.return_value = None
+                await c.login()
+        assert c._client is mock_garmin
+
+    async def test_login_fails_marks_task_failed(self, tracker: TaskTracker) -> None:
+        c = GarminWellnessConnector("g", _CREDS, tracker)
+        with patch("app.connectors.garmin_wellness.Garmin") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            with patch(
+                "app.connectors.garmin_wellness._run_with_timeout",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("auth error"),
+            ):
+                with pytest.raises(RuntimeError):
+                    await c.login()
+
+
+class TestFetchDaily:
+    async def test_fetch_sleep(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_daily(WellnessDataType.SLEEP, _START)
+        assert result is not None
+        fake_garmin.get_sleep_data.assert_called_once_with("2026-01-01")
+
+    async def test_fetch_hrv_none_is_skipped(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        fake_garmin.get_hrv_data.return_value = None
+        result = await connector.fetch_daily(WellnessDataType.HRV, _START)
+        assert result is None
+
+    async def test_fetch_resting_hr(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_daily(WellnessDataType.RESTING_HR, _START)
+        assert result is not None
+        fake_garmin.get_rhr_day.assert_called_once_with("2026-01-01")
+
+    async def test_fetch_body_battery_events_list_wrapped(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        fake_garmin.get_body_battery_events.return_value = [{"event": "charged"}]
+        result = await connector.fetch_daily(
+            WellnessDataType.BODY_BATTERY_EVENTS, _START
+        )
+        assert result == {"items": [{"event": "charged"}]}
+
+    async def test_fetch_exception_returns_none(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        fake_garmin.get_sleep_data.side_effect = RuntimeError("network error")
+        result = await connector.fetch_daily(WellnessDataType.SLEEP, _START)
+        assert result is None
+
+    async def test_fetch_unsupported_type_returns_none(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        result = await connector.fetch_daily(WellnessDataType.ATHLETE_STATS, _START)
+        assert result is None
+
+    async def test_requires_client(self, tracker: TaskTracker) -> None:
+        c = GarminWellnessConnector("g", _CREDS, tracker)
+        with pytest.raises(RuntimeError, match="Not logged in"):
+            await c.fetch_daily(WellnessDataType.SLEEP, _START)
+
+    async def test_all_daily_types_dispatch(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        from app.connectors.wellness_base import TimeModel
+
+        daily_types = [
+            dt
+            for dt, spec in GARMIN_CAPABILITIES.items()
+            if spec.time_model == TimeModel.DAILY
+        ]
+        for dt in daily_types:
+            result = await connector.fetch_daily(dt, _START)
+            assert result is not None or result is None  # just no exception
+
+
+class TestFetchRange:
+    async def test_fetch_body_battery(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.BODY_BATTERY, _START, _END
+        )
+        assert result is not None
+        fake_garmin.get_body_battery.assert_called_once_with("2026-01-01", "2026-01-31")
+
+    async def test_fetch_body_composition(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.BODY_COMPOSITION, _START, _END
+        )
+        assert result is not None
+
+    async def test_fetch_weekly_steps_uses_end_and_weeks(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.WEEKLY_STEPS, _START, _END
+        )
+        assert result is not None
+        call_args = fake_garmin.get_weekly_steps.call_args
+        assert call_args[0][0] == "2026-01-31"
+        assert isinstance(call_args[0][1], int)
+        assert call_args[0][1] >= 1
+
+    async def test_fetch_weekly_intensity_minutes_uses_start_end(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.WEEKLY_INTENSITY_MINUTES, _START, _END
+        )
+        assert result is not None
+        fake_garmin.get_weekly_intensity_minutes.assert_called_once_with(
+            "2026-01-01", "2026-01-31"
+        )
+
+    async def test_fetch_exception_returns_none(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        fake_garmin.get_body_battery.side_effect = RuntimeError("error")
+        result = await connector.fetch_range(
+            WellnessDataType.BODY_BATTERY, _START, _END
+        )
+        assert result is None
+
+    async def test_fetch_unsupported_returns_none(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.ATHLETE_STATS, _START, _END
+        )
+        assert result is None
+
+    async def test_all_range_types_dispatch(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        from app.connectors.wellness_base import TimeModel
+
+        range_types = [
+            dt
+            for dt, spec in GARMIN_CAPABILITIES.items()
+            if spec.time_model == TimeModel.RANGE
+        ]
+        for dt in range_types:
+            result = await connector.fetch_range(dt, _START, _END)
+            assert result is not None or result is None
+
+
+class TestFetchSnapshot:
+    async def test_fetch_personal_records(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result is not None
+        fake_garmin.get_personal_record.assert_called_once()
+
+    async def test_fetch_unsupported_snapshot(
+        self, connector: GarminWellnessConnector
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.ATHLETE_STATS)
+        assert result is None
+
+    async def test_fetch_exception_returns_none(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        fake_garmin.get_personal_record.side_effect = RuntimeError("error")
+        result = await connector.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result is None
+
+
+class TestPushRecord:
+    async def test_push_weigh_in(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(
+            WellnessDataType.DAILY_WEIGH_INS, _START, {"weight": 75.5}
+        )
+        fake_garmin.add_weigh_in.assert_called_once_with(75.5)
+
+    async def test_push_hydration(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(
+            WellnessDataType.HYDRATION,
+            _START,
+            {"value_in_ml": 2000.0},
+        )
+        fake_garmin.add_hydration_data.assert_called_once()
+
+    async def test_push_body_composition(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(
+            WellnessDataType.BODY_COMPOSITION,
+            _START,
+            {"weight": 75.0, "timestamp": "2026-01-01T08:00:00"},
+        )
+        fake_garmin.add_body_composition.assert_called_once()
+
+    async def test_push_blood_pressure(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(
+            WellnessDataType.BLOOD_PRESSURE,
+            _START,
+            {"systolic": 120, "diastolic": 80, "pulse": 70},
+        )
+        fake_garmin.set_blood_pressure.assert_called_once_with(120, 80, 70)
+
+    async def test_push_read_only_type_logs_unsupported(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(WellnessDataType.SLEEP, _START, {"sleepData": []})
+        fake_garmin.add_weigh_in.assert_not_called()
+
+    async def test_push_weigh_in_missing_weight_skips_call(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(WellnessDataType.DAILY_WEIGH_INS, _START, {})
+        fake_garmin.add_weigh_in.assert_not_called()
+
+    async def test_push_exception_logs_warning(
+        self, tracker: TaskTracker, fake_garmin: MagicMock
+    ) -> None:
+        log = MagicMock()
+        log.warning = MagicMock()
+        tracker_with_log = TaskTracker(_FakeRenderer(), sync_logger=log)
+        c = GarminWellnessConnector(
+            "garmin-main", _CREDS, tracker_with_log, client=fake_garmin
+        )
+        fake_garmin.add_weigh_in.side_effect = RuntimeError("push failed")
+        await c.push_record(WellnessDataType.DAILY_WEIGH_INS, _START, {"weight": 75.0})
+        log.warning.assert_called_once()
+
+    async def test_push_weigh_ins_range(
+        self, connector: GarminWellnessConnector, fake_garmin: MagicMock
+    ) -> None:
+        await connector.push_record(
+            WellnessDataType.WEIGH_INS,
+            _START,
+            {"weight": 75.0, "timestamp": "2026-01-01T08:00:00"},
+        )
+        fake_garmin.add_body_composition.assert_called_once()
+
+
+class TestFromGarminConnector:
+    def test_creates_from_connector(self, tracker: TaskTracker) -> None:
+        from app.connectors.garmin import GarminConnector
+
+        gc = GarminConnector(_CREDS, tracker)
+        fake_client = MagicMock()
+        gc._client = fake_client
+        wc = GarminWellnessConnector.from_garmin_connector("garmin-main", gc, tracker)
+        assert wc.connector_id == "garmin-main"
+        assert wc._client is fake_client
+
+
+class TestNormalizeResult:
+    def test_none_stays_none(self) -> None:
+        assert _normalize_result(None) is None
+
+    def test_dict_unchanged(self) -> None:
+        d = {"key": "val"}
+        assert _normalize_result(d) is d
+
+    def test_list_wrapped(self) -> None:
+        result = _normalize_result([1, 2, 3])
+        assert result == {"items": [1, 2, 3]}
+
+    def test_scalar_wrapped(self) -> None:
+        result = _normalize_result(42)
+        assert result == {"value": 42}

--- a/tests/connectors/test_local_folder_wellness.py
+++ b/tests/connectors/test_local_folder_wellness.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app.connectors.local_folder_wellness import LocalFolderWellnessConnector
+from app.connectors.wellness_base import WellnessDataType
+from app.connectors.wellness_capabilities import LOCAL_FOLDER_CAPABILITIES
+from app.tracking.tracker import ProgressRenderer, Task, TaskStatus, TaskTracker
+
+
+class _FakeRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None:
+        pass
+
+    def on_progress(self, task: Task) -> None:
+        pass
+
+    def on_task_done(self, task: Task) -> None:
+        pass
+
+    def on_task_failed(self, task: Task) -> None:
+        pass
+
+    def on_task_warning(self, task: Task, message: str) -> None:
+        pass
+
+    def on_total_updated(self, task: Task) -> None:
+        pass
+
+
+@pytest.fixture
+def tracker() -> TaskTracker:
+    return TaskTracker(_FakeRenderer())
+
+
+@pytest.fixture
+def folder(tmp_path: Path) -> Path:
+    p = tmp_path / "local"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def connector(folder: Path, tracker: TaskTracker) -> LocalFolderWellnessConnector:
+    return LocalFolderWellnessConnector("local-main", folder, tracker)
+
+
+class TestConnectorId:
+    def test_returns_configured_id(
+        self, connector: LocalFolderWellnessConnector
+    ) -> None:
+        assert connector.connector_id == "local-main"
+
+
+class TestSupportedTypes:
+    def test_returns_local_folder_capabilities(
+        self, connector: LocalFolderWellnessConnector
+    ) -> None:
+        assert connector.supported_types() == LOCAL_FOLDER_CAPABILITIES
+
+
+class TestLogin:
+    async def test_login_succeeds_for_existing_folder(
+        self, connector: LocalFolderWellnessConnector, tracker: TaskTracker
+    ) -> None:
+        await connector.login()
+        tasks = tracker.tasks
+        task = next(t for n, t in tasks.items() if "Local folder wellness" in n)
+        assert task.status == TaskStatus.DONE
+
+    async def test_login_fails_for_missing_folder(
+        self, tmp_path: Path, tracker: TaskTracker
+    ) -> None:
+        c = LocalFolderWellnessConnector(
+            "local-main", tmp_path / "nonexistent", tracker
+        )
+        with pytest.raises(FileNotFoundError):
+            await c.login()
+
+    async def test_login_marks_task_failed_on_error(
+        self, tmp_path: Path, tracker: TaskTracker
+    ) -> None:
+        c = LocalFolderWellnessConnector(
+            "local-main", tmp_path / "nonexistent", tracker
+        )
+        with pytest.raises(FileNotFoundError):
+            await c.login()
+        tasks = tracker.tasks
+        task = next(t for n, t in tasks.items() if "Local folder wellness" in n)
+        assert task.status == TaskStatus.FAILED
+
+
+class TestPushRecord:
+    async def test_push_daily_creates_file(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        d = date(2026, 1, 15)
+        data = {"steps": 8000}
+        await connector.push_record(WellnessDataType.STEPS_DAILY, d, data)
+        p = folder / "wellness" / "steps_daily" / "2026-01-15.json"
+        assert p.is_file()
+        assert json.loads(p.read_text()) == data
+
+    async def test_push_snapshot_creates_snapshot_file(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        data: dict[str, list[object]] = {"records": []}
+        await connector.push_record(WellnessDataType.PERSONAL_RECORDS, None, data)
+        p = folder / "wellness" / "personal_records" / "snapshot.json"
+        assert p.is_file()
+        assert json.loads(p.read_text()) == data
+
+    async def test_push_overwrites_existing(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        d = date(2026, 1, 1)
+        await connector.push_record(WellnessDataType.SLEEP, d, {"v": 1})
+        await connector.push_record(WellnessDataType.SLEEP, d, {"v": 2})
+        p = folder / "wellness" / "sleep" / "2026-01-01.json"
+        assert json.loads(p.read_text())["v"] == 2
+
+    async def test_push_creates_parent_dirs(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        await connector.push_record(WellnessDataType.HRV, date(2026, 1, 1), {"hrv": 50})
+        assert (folder / "wellness" / "hrv").is_dir()
+
+    async def test_push_atomic_write(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        d = date(2026, 1, 1)
+        await connector.push_record(WellnessDataType.SLEEP, d, {"data": "test"})
+        p = folder / "wellness" / "sleep" / "2026-01-01.json"
+        tmp = p.with_suffix(".tmp")
+        assert not tmp.exists()
+        assert p.is_file()
+
+
+class TestFetchDaily:
+    async def test_returns_none_when_file_missing(
+        self, connector: LocalFolderWellnessConnector
+    ) -> None:
+        result = await connector.fetch_daily(WellnessDataType.SLEEP, date(2026, 1, 1))
+        assert result is None
+
+    async def test_returns_data_when_file_exists(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        d = date(2026, 1, 15)
+        data: dict[str, list[object]] = {"sleepData": []}
+        await connector.push_record(WellnessDataType.SLEEP, d, data)
+        result = await connector.fetch_daily(WellnessDataType.SLEEP, d)
+        assert result == data
+
+
+class TestFetchRange:
+    async def test_returns_none_when_file_missing(
+        self, connector: LocalFolderWellnessConnector
+    ) -> None:
+        result = await connector.fetch_range(
+            WellnessDataType.BODY_BATTERY, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is None
+
+    async def test_returns_data_when_file_exists(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        start = date(2026, 1, 1)
+        end = date(2026, 1, 31)
+        data: dict[str, list[object]] = {"battery": []}
+        key = f"{start}_{end}"
+        p = folder / "wellness" / "body_battery" / f"{key}.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(data), encoding="utf-8")
+        result = await connector.fetch_range(WellnessDataType.BODY_BATTERY, start, end)
+        assert result == data
+
+
+class TestFetchSnapshot:
+    async def test_returns_none_when_file_missing(
+        self, connector: LocalFolderWellnessConnector
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result is None
+
+    async def test_returns_data_when_file_exists(
+        self, connector: LocalFolderWellnessConnector, folder: Path
+    ) -> None:
+        data = {"records": [{"type": "run"}]}
+        await connector.push_record(WellnessDataType.PERSONAL_RECORDS, None, data)
+        result = await connector.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result == data

--- a/tests/connectors/test_strava_wellness.py
+++ b/tests/connectors/test_strava_wellness.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.connectors.strava_wellness import StravaWellnessConnector
+from app.connectors.wellness_base import WellnessDataType
+from app.connectors.wellness_capabilities import STRAVA_CAPABILITIES
+from app.tracking.tracker import ProgressRenderer, Task, TaskTracker
+
+
+class _FakeRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None:
+        pass
+
+    def on_progress(self, task: Task) -> None:
+        pass
+
+    def on_task_done(self, task: Task) -> None:
+        pass
+
+    def on_task_failed(self, task: Task) -> None:
+        pass
+
+    def on_task_warning(self, task: Task, message: str) -> None:
+        pass
+
+    def on_total_updated(self, task: Task) -> None:
+        pass
+
+
+@pytest.fixture
+def tracker() -> TaskTracker:
+    return TaskTracker(_FakeRenderer())
+
+
+@pytest.fixture
+def fake_strava_client() -> MagicMock:
+    client = MagicMock()
+    athlete = MagicMock()
+    athlete.id = 12345
+
+    stats = MagicMock()
+    stats.model_dump_json.return_value = '{"all_run_totals": {"count": 10}}'
+
+    zones = MagicMock()
+    zones.model_dump_json.return_value = '{"heart_rate": {"custom_zones": false}}'
+
+    client.get_athlete.return_value = athlete
+    client.get_athlete_stats.return_value = stats
+    client.get_athlete_zones.return_value = zones
+    return client
+
+
+@pytest.fixture
+def connector(
+    tracker: TaskTracker, fake_strava_client: MagicMock
+) -> StravaWellnessConnector:
+    return StravaWellnessConnector("strava-main", fake_strava_client, tracker)
+
+
+class TestConnectorId:
+    def test_returns_configured_id(self, connector: StravaWellnessConnector) -> None:
+        assert connector.connector_id == "strava-main"
+
+
+class TestSupportedTypes:
+    def test_returns_strava_capabilities(
+        self, connector: StravaWellnessConnector
+    ) -> None:
+        assert connector.supported_types() == STRAVA_CAPABILITIES
+
+
+class TestLogin:
+    async def test_login_creates_and_finishes_task(
+        self, connector: StravaWellnessConnector, tracker: TaskTracker
+    ) -> None:
+        await connector.login()
+        tasks = tracker.tasks
+        assert any("Strava wellness" in name for name in tasks)
+        task = next(t for n, t in tasks.items() if "Strava wellness" in n)
+        from app.tracking.tracker import TaskStatus
+
+        assert task.status == TaskStatus.DONE
+
+
+class TestFetchSnapshot:
+    async def test_fetch_athlete_stats(
+        self, connector: StravaWellnessConnector, fake_strava_client: MagicMock
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.ATHLETE_STATS)
+        assert result is not None
+        assert "all_run_totals" in result
+
+    async def test_fetch_athlete_zones(
+        self, connector: StravaWellnessConnector, fake_strava_client: MagicMock
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.ATHLETE_ZONES)
+        assert result is not None
+        assert "heart_rate" in result
+
+    async def test_fetch_unsupported_returns_none(
+        self, connector: StravaWellnessConnector
+    ) -> None:
+        result = await connector.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result is None
+
+    async def test_fetch_stats_exception_returns_none(
+        self, connector: StravaWellnessConnector, fake_strava_client: MagicMock
+    ) -> None:
+        fake_strava_client.get_athlete.side_effect = RuntimeError("network error")
+        result = await connector.fetch_snapshot(WellnessDataType.ATHLETE_STATS)
+        assert result is None
+
+    async def test_fetch_zones_exception_returns_none(
+        self, connector: StravaWellnessConnector, fake_strava_client: MagicMock
+    ) -> None:
+        fake_strava_client.get_athlete_zones.side_effect = RuntimeError("network error")
+        result = await connector.fetch_snapshot(WellnessDataType.ATHLETE_ZONES)
+        assert result is None
+
+    async def test_fetch_stats_logs_on_error(self, tracker: TaskTracker) -> None:
+        log = MagicMock()
+        log.debug = MagicMock()
+        tracker_with_log = TaskTracker(_FakeRenderer(), sync_logger=log)
+        client = MagicMock()
+        client.get_athlete.side_effect = RuntimeError("fail")
+        c = StravaWellnessConnector("strava-main", client, tracker_with_log)
+        result = await c.fetch_snapshot(WellnessDataType.ATHLETE_STATS)
+        assert result is None
+        log.debug.assert_called_once()
+
+    async def test_athlete_id_used_for_stats(
+        self, connector: StravaWellnessConnector, fake_strava_client: MagicMock
+    ) -> None:
+        await connector.fetch_snapshot(WellnessDataType.ATHLETE_STATS)
+        fake_strava_client.get_athlete_stats.assert_called_once_with(12345)

--- a/tests/connectors/test_wellness_base.py
+++ b/tests/connectors/test_wellness_base.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.connectors.wellness_base import (
+    AccessLevel,
+    DataTypeSpec,
+    TimeModel,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.tracking.tracker import ProgressRenderer, Task, TaskTracker
+
+
+class _FakeRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None:
+        pass
+
+    def on_progress(self, task: Task) -> None:
+        pass
+
+    def on_task_done(self, task: Task) -> None:
+        pass
+
+    def on_task_failed(self, task: Task) -> None:
+        pass
+
+    def on_task_warning(self, task: Task, message: str) -> None:
+        pass
+
+    def on_total_updated(self, task: Task) -> None:
+        pass
+
+
+@pytest.fixture
+def tracker() -> TaskTracker:
+    return TaskTracker(_FakeRenderer())
+
+
+@pytest.fixture
+def tracker_with_log() -> TaskTracker:
+    log = MagicMock()
+    log.debug = MagicMock()
+    return TaskTracker(_FakeRenderer(), sync_logger=log)
+
+
+class _ConcreteConnector(WellnessConnector):
+    @property
+    def connector_id(self) -> str:
+        return "test-connector"
+
+    async def login(self) -> None:
+        pass
+
+
+class TestWellnessConnectorDefaults:
+    async def test_fetch_daily_returns_none(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        result = await c.fetch_daily(WellnessDataType.SLEEP, date(2026, 1, 1))
+        assert result is None
+
+    async def test_fetch_range_returns_none(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        result = await c.fetch_range(
+            WellnessDataType.BODY_BATTERY, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is None
+
+    async def test_fetch_snapshot_returns_none(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        result = await c.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result is None
+
+    async def test_push_record_does_nothing(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        await c.push_record(WellnessDataType.SLEEP, date(2026, 1, 1), {})
+
+    def test_supported_types_empty(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        assert c.supported_types() == {}
+
+    async def test_log_unsupported_calls_debug(
+        self, tracker_with_log: TaskTracker
+    ) -> None:
+        c = _ConcreteConnector(tracker_with_log)
+        await c.fetch_daily(WellnessDataType.SLEEP, date(2026, 1, 1))
+        assert tracker_with_log.sync_logger is not None
+        tracker_with_log.sync_logger.debug.assert_called_once()  # type: ignore[attr-defined]
+        call_arg = tracker_with_log.sync_logger.debug.call_args[0][0]  # type: ignore[attr-defined]
+        assert "fetch_daily" in call_arg
+        assert "sleep" in call_arg
+
+    async def test_log_unsupported_no_log(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        # Should not raise even without a logger
+        await c.fetch_daily(WellnessDataType.SLEEP, date(2026, 1, 1))
+
+
+class TestFindEarliestSupportedDate:
+    async def test_returns_none_when_hi_fails(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            return None
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2020, 1, 1), date(2026, 1, 1)
+        )
+        assert result is None
+
+    async def test_returns_none_when_hi_raises(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            raise RuntimeError("network error")
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2020, 1, 1), date(2026, 1, 1)
+        )
+        assert result is None
+
+    async def test_returns_hi_when_all_succeed(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            return {"ok": True}
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is not None
+        assert result <= date(2026, 1, 1)
+
+    async def test_bisects_to_earliest_success(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+        cutoff = date(2026, 1, 15)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            return {"ok": True} if d >= cutoff else None
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is not None
+        assert result <= cutoff
+
+    async def test_returns_hi_when_lo_equals_hi(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            return {}
+
+        d = date(2026, 1, 15)
+        result = await c._find_earliest_supported_date(probe, d, d)
+        assert result == d
+
+    async def test_empty_dict_counts_as_success(self, tracker: TaskTracker) -> None:
+        c = _ConcreteConnector(tracker)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            return {}
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is not None
+
+    async def test_probe_exception_treated_as_failure(
+        self, tracker: TaskTracker
+    ) -> None:
+        c = _ConcreteConnector(tracker)
+        cutoff = date(2026, 1, 20)
+
+        async def probe(d: date, hi: date) -> dict | None:
+            if d < cutoff:
+                raise ValueError("too early")
+            return {"ok": True}
+
+        result = await c._find_earliest_supported_date(
+            probe, date(2026, 1, 1), date(2026, 1, 31)
+        )
+        assert result is not None
+        assert result <= cutoff
+
+
+class TestDataTypeSpec:
+    def test_frozen(self) -> None:
+        import dataclasses
+
+        spec = DataTypeSpec(TimeModel.DAILY, AccessLevel.READ)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            spec.time_model = TimeModel.RANGE  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        a = DataTypeSpec(TimeModel.DAILY, AccessLevel.READ)
+        b = DataTypeSpec(TimeModel.DAILY, AccessLevel.READ)
+        assert a == b
+
+    def test_inequality(self) -> None:
+        a = DataTypeSpec(TimeModel.DAILY, AccessLevel.READ)
+        b = DataTypeSpec(TimeModel.RANGE, AccessLevel.READ)
+        assert a != b
+
+
+class TestEnums:
+    def test_wellness_data_type_values(self) -> None:
+        assert WellnessDataType.SLEEP.value == "sleep"
+        assert WellnessDataType.ATHLETE_STATS.value == "athlete_stats"
+
+    def test_time_model_values(self) -> None:
+        assert TimeModel.DAILY.value == "daily"
+        assert TimeModel.RANGE.value == "range"
+        assert TimeModel.SNAPSHOT.value == "snapshot"
+
+    def test_access_level_values(self) -> None:
+        assert AccessLevel.READ.value == "read"
+        assert AccessLevel.READ_WRITE.value == "read_write"

--- a/tests/core/test_wellness_cache.py
+++ b/tests/core/test_wellness_cache.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app.connectors.wellness_base import WellnessDataType
+from app.core.wellness_cache import WellnessCache
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> WellnessCache:
+    return WellnessCache(tmp_path / "cache")
+
+
+class TestHas:
+    def test_returns_false_when_no_file(self, cache: WellnessCache) -> None:
+        assert not cache.has("garmin", WellnessDataType.SLEEP, "2026-01-01")
+
+    def test_returns_true_after_write(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 1})
+        assert cache.has("garmin", WellnessDataType.SLEEP, "2026-01-01")
+
+    def test_different_connector_returns_false(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 1})
+        assert not cache.has("strava", WellnessDataType.SLEEP, "2026-01-01")
+
+    def test_different_data_type_returns_false(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 1})
+        assert not cache.has("garmin", WellnessDataType.HRV, "2026-01-01")
+
+    def test_different_date_key_returns_false(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 1})
+        assert not cache.has("garmin", WellnessDataType.SLEEP, "2026-01-02")
+
+
+class TestRead:
+    def test_returns_none_when_no_file(self, cache: WellnessCache) -> None:
+        assert cache.read("garmin", WellnessDataType.SLEEP, "2026-01-01") is None
+
+    def test_returns_written_data(self, cache: WellnessCache) -> None:
+        data = {"sleepData": [1, 2, 3]}
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", data)
+        result = cache.read("garmin", WellnessDataType.SLEEP, "2026-01-01")
+        assert result == data
+
+    def test_preserves_unicode(self, cache: WellnessCache) -> None:
+        data = {"name": "h\u00e9ros"}
+        cache.write("garmin", WellnessDataType.SLEEP, "key", data)
+        result = cache.read("garmin", WellnessDataType.SLEEP, "key")
+        assert result == data
+
+
+class TestWrite:
+    def test_creates_parent_directories(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {})
+        p = cache._dir / "garmin" / "sleep" / "2026-01-01.json"
+        assert p.is_file()
+
+    def test_overwrites_existing(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 1})
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {"v": 2})
+        result = cache.read("garmin", WellnessDataType.SLEEP, "2026-01-01")
+        assert result == {"v": 2}
+
+    def test_atomic_no_tmp_left_over(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {})
+        tmp = cache._dir / "garmin" / "sleep" / "2026-01-01.tmp"
+        assert not tmp.exists()
+
+    def test_valid_json_written(self, cache: WellnessCache) -> None:
+        data = {"key": [1, 2, 3], "nested": {"a": True}}
+        cache.write("garmin", WellnessDataType.HRV, "key", data)
+        p = cache._dir / "garmin" / "hrv" / "key.json"
+        loaded = json.loads(p.read_text(encoding="utf-8"))
+        assert loaded == data
+
+
+class TestInvalidate:
+    def test_removes_connector_directory(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {})
+        cache.write("garmin", WellnessDataType.HRV, "2026-01-01", {})
+        cache.invalidate("garmin")
+        assert not (cache._dir / "garmin").exists()
+
+    def test_does_not_affect_other_connectors(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {})
+        cache.write("strava", WellnessDataType.ATHLETE_STATS, "snapshot", {})
+        cache.invalidate("garmin")
+        assert cache.has("strava", WellnessDataType.ATHLETE_STATS, "snapshot")
+
+    def test_no_error_when_connector_not_cached(self, cache: WellnessCache) -> None:
+        cache.invalidate("garmin")  # Should not raise
+
+    def test_has_returns_false_after_invalidate(self, cache: WellnessCache) -> None:
+        cache.write("garmin", WellnessDataType.SLEEP, "2026-01-01", {})
+        cache.invalidate("garmin")
+        assert not cache.has("garmin", WellnessDataType.SLEEP, "2026-01-01")
+
+
+class TestKeyHelpers:
+    def test_range_key(self) -> None:
+        start = date(2026, 1, 1)
+        end = date(2026, 12, 31)
+        assert WellnessCache.range_key(start, end) == "2026-01-01_2026-12-31"
+
+    def test_daily_key(self) -> None:
+        d = date(2026, 6, 15)
+        assert WellnessCache.daily_key(d) == "2026-06-15"
+
+    def test_snapshot_key(self) -> None:
+        assert WellnessCache.SNAPSHOT_KEY == "snapshot"
+
+    def test_range_key_same_start_end(self) -> None:
+        d = date(2026, 1, 1)
+        key = WellnessCache.range_key(d, d)
+        assert key == "2026-01-01_2026-01-01"

--- a/tests/core/test_wellness_orchestrator.py
+++ b/tests/core/test_wellness_orchestrator.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.connectors.local_folder_wellness import LocalFolderWellnessConnector
+from app.connectors.wellness_base import (
+    AccessLevel,
+    DataTypeSpec,
+    TimeModel,
+    WellnessConnector,
+    WellnessDataType,
+)
+from app.core.wellness_cache import WellnessCache
+from app.core.wellness_orchestrator import WellnessOrchestrator
+from app.tracking.tracker import ProgressRenderer, Task, TaskStatus, TaskTracker
+
+_START = date(2026, 1, 1)
+_END = date(2026, 1, 3)
+
+
+class _FakeRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None:
+        pass
+
+    def on_progress(self, task: Task) -> None:
+        pass
+
+    def on_task_done(self, task: Task) -> None:
+        pass
+
+    def on_task_failed(self, task: Task) -> None:
+        pass
+
+    def on_task_warning(self, task: Task, message: str) -> None:
+        pass
+
+    def on_total_updated(self, task: Task) -> None:
+        pass
+
+
+@pytest.fixture
+def tracker() -> TaskTracker:
+    return TaskTracker(_FakeRenderer())
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> WellnessCache:
+    return WellnessCache(tmp_path / "cache")
+
+
+def _make_source_connector(
+    connector_id: str,
+    tracker: TaskTracker,
+    *,
+    daily_types: list[WellnessDataType] | None = None,
+    range_types: list[WellnessDataType] | None = None,
+    snapshot_types: list[WellnessDataType] | None = None,
+    daily_data: dict | None = None,
+    range_data: dict | None = None,
+    snapshot_data: dict | None = None,
+) -> WellnessConnector:
+    supported: dict[WellnessDataType, DataTypeSpec] = {}
+    for dt in daily_types or []:
+        supported[dt] = DataTypeSpec(TimeModel.DAILY, AccessLevel.READ)
+    for dt in range_types or []:
+        supported[dt] = DataTypeSpec(TimeModel.RANGE, AccessLevel.READ)
+    for dt in snapshot_types or []:
+        supported[dt] = DataTypeSpec(TimeModel.SNAPSHOT, AccessLevel.READ)
+
+    conn = MagicMock(spec=WellnessConnector)
+    conn.connector_id = connector_id
+    conn.supported_types.return_value = supported
+    conn.fetch_daily = AsyncMock(return_value=daily_data or {"data": "daily"})
+    conn.fetch_range = AsyncMock(return_value=range_data or {"data": "range"})
+    conn.fetch_snapshot = AsyncMock(return_value=snapshot_data or {"data": "snapshot"})
+    conn.push_record = AsyncMock()
+    return conn
+
+
+def _make_local_folder_connector(
+    connector_id: str,
+    folder: Path,
+    tracker: TaskTracker,
+) -> LocalFolderWellnessConnector:
+    c = LocalFolderWellnessConnector(connector_id, folder, tracker)
+    return c
+
+
+class TestRunDownload:
+    async def test_fetches_daily_for_each_date(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        assert source.fetch_daily.call_count == 3  # type: ignore[union-attr, attr-defined]
+
+    async def test_fetches_range_once(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, range_types=[WellnessDataType.BODY_BATTERY]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        source.fetch_range.assert_called_once()  # type: ignore[union-attr, attr-defined]
+
+    async def test_fetches_snapshot_once(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, snapshot_types=[WellnessDataType.PERSONAL_RECORDS]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        source.fetch_snapshot.assert_called_once()  # type: ignore[union-attr, attr-defined]
+
+    async def test_caches_fetched_daily_data(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        key = WellnessCache.daily_key(_START)
+        assert cache.has("garmin", WellnessDataType.SLEEP, key)
+        assert cache.read("garmin", WellnessDataType.SLEEP, key) == {"data": "daily"}
+
+    async def test_caches_fetched_range_data(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, range_types=[WellnessDataType.BODY_BATTERY]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        key = WellnessCache.range_key(_START, _END)
+        assert cache.has("garmin", WellnessDataType.BODY_BATTERY, key)
+
+    async def test_skips_cached_daily_data(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        key = WellnessCache.daily_key(_START)
+        cache.write("garmin", WellnessDataType.SLEEP, key, {"cached": True})
+
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        assert source.fetch_daily.call_count == 2  # type: ignore[union-attr, attr-defined]
+
+    async def test_skips_cached_range_data(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, range_types=[WellnessDataType.BODY_BATTERY]
+        )
+        key = WellnessCache.range_key(_START, _END)
+        cache.write("garmin", WellnessDataType.BODY_BATTERY, key, {"cached": True})
+
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        source.fetch_range.assert_not_called()  # type: ignore[union-attr, attr-defined]
+
+    async def test_skips_cached_snapshot_data(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, snapshot_types=[WellnessDataType.PERSONAL_RECORDS]
+        )
+        cache.write(
+            "garmin",
+            WellnessDataType.PERSONAL_RECORDS,
+            WellnessCache.SNAPSHOT_KEY,
+            {"cached": True},
+        )
+
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        source.fetch_snapshot.assert_not_called()  # type: ignore[union-attr, attr-defined]
+
+    async def test_does_not_cache_none_result(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin",
+            tracker,
+            daily_types=[WellnessDataType.SLEEP],
+            daily_data=None,
+        )
+        source.fetch_daily = AsyncMock(return_value=None)  # type: ignore[union-attr, method-assign]
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        key = WellnessCache.daily_key(_START)
+        assert not cache.has("garmin", WellnessDataType.SLEEP, key)
+
+
+class TestRunForce:
+    async def test_force_invalidates_cache(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        key = WellnessCache.daily_key(_START)
+        cache.write("garmin", WellnessDataType.SLEEP, key, {"old": True})
+
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END, force=True)
+
+        assert source.fetch_daily.call_count == 3  # type: ignore[union-attr, attr-defined]
+        result = cache.read("garmin", WellnessDataType.SLEEP, key)
+        assert result == {"data": "daily"}
+
+    async def test_no_force_uses_cache(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        key = WellnessCache.daily_key(_START)
+        cache.write("garmin", WellnessDataType.SLEEP, key, {"old": True})
+
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END, force=False)
+
+        assert source.fetch_daily.call_count == 2  # type: ignore[union-attr, attr-defined]
+
+
+class TestRunUpload:
+    async def test_pushes_cached_data_to_local_folder(
+        self, cache: WellnessCache, tracker: TaskTracker, tmp_path: Path
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        dest_folder = tmp_path / "dest"
+        dest_folder.mkdir()
+        dest = _make_local_folder_connector("local", dest_folder, tracker)
+
+        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        await orch.run(_START, _END)
+
+        for d_offset in range(3):
+            from datetime import timedelta
+
+            d = _START + timedelta(days=d_offset)
+            result = await dest.fetch_daily(WellnessDataType.SLEEP, d)
+            assert result == {"data": "daily"}
+
+    async def test_no_upload_task_when_nothing_to_push(
+        self, cache: WellnessCache, tracker: TaskTracker, tmp_path: Path
+    ) -> None:
+        source = _make_source_connector(
+            "garmin",
+            tracker,
+            daily_types=[WellnessDataType.SLEEP],
+            daily_data=None,
+        )
+        source.fetch_daily = AsyncMock(return_value=None)  # type: ignore[union-attr, method-assign]
+        dest_folder = tmp_path / "dest"
+        dest_folder.mkdir()
+        dest = _make_local_folder_connector("local", dest_folder, tracker)
+
+        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        await orch.run(_START, _END)
+
+        tasks = tracker.tasks
+        upload_tasks = [n for n in tasks if "Wellness upload" in n]
+        assert len(upload_tasks) == 0
+
+    async def test_pushes_snapshot_to_local_folder(
+        self, cache: WellnessCache, tracker: TaskTracker, tmp_path: Path
+    ) -> None:
+        source = _make_source_connector(
+            "garmin",
+            tracker,
+            snapshot_types=[WellnessDataType.PERSONAL_RECORDS],
+            snapshot_data={"records": [{"type": "run"}]},
+        )
+        dest_folder = tmp_path / "dest"
+        dest_folder.mkdir()
+        dest = _make_local_folder_connector("local", dest_folder, tracker)
+
+        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        await orch.run(_START, _END)
+
+        result = await dest.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
+        assert result == {"records": [{"type": "run"}]}
+
+
+class TestProgressTracking:
+    async def test_download_task_created_and_finished(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        tasks = tracker.tasks
+        download_tasks = [
+            t for n, t in tasks.items() if "Wellness download (garmin)" in n
+        ]
+        assert len(download_tasks) == 1
+        assert download_tasks[0].status == TaskStatus.DONE
+
+    async def test_upload_task_created_and_finished(
+        self, cache: WellnessCache, tracker: TaskTracker, tmp_path: Path
+    ) -> None:
+        source = _make_source_connector(
+            "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
+        )
+        dest_folder = tmp_path / "dest"
+        dest_folder.mkdir()
+        dest = _make_local_folder_connector("local", dest_folder, tracker)
+
+        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        await orch.run(_START, _END)
+
+        tasks = tracker.tasks
+        upload_tasks = [t for n, t in tasks.items() if "Wellness upload (local)" in n]
+        assert len(upload_tasks) == 1
+        assert upload_tasks[0].status == TaskStatus.DONE
+
+    async def test_no_download_task_when_no_supported_types(
+        self, cache: WellnessCache, tracker: TaskTracker
+    ) -> None:
+        source = _make_source_connector("garmin", tracker)
+        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        await orch.run(_START, _END)
+
+        tasks = tracker.tasks
+        download_tasks = [n for n in tasks if "Wellness download" in n]
+        assert len(download_tasks) == 0
+
+
+class TestLocalFolderNotTreatedAsSource:
+    async def test_local_folder_not_fetched_from(
+        self, cache: WellnessCache, tracker: TaskTracker, tmp_path: Path
+    ) -> None:
+        folder = tmp_path / "local"
+        folder.mkdir()
+        dest = _make_local_folder_connector("local", folder, tracker)
+
+        orch = WellnessOrchestrator({"local": dest}, cache, tracker)
+        await orch.run(_START, _END)
+
+        tasks = tracker.tasks
+        download_tasks = [n for n in tasks if "Wellness download" in n]
+        assert len(download_tasks) == 0


### PR DESCRIPTION
## Summary

- Adds `WellnessConnector` ABC with DAILY / RANGE / SNAPSHOT time model and READ / READ_WRITE access taxonomy
- Implements `GarminWellnessConnector` (35 data types, push for writable types), `StravaWellnessConnector` (athlete stats + zones), and `LocalFolderWellnessConnector` (file-based store)
- `WellnessCache` — file-based cache with `invalidate(connector_id)` for `--force` runs
- `WellnessOrchestrator` — async concurrent download pipeline (`asyncio.Semaphore(5)`) + upload to local destinations
- `--skip-wellness` CLI flag (wellness sync enabled by default)
- Capabilities for all connectors defined statically in `app/connectors/wellness_capabilities.py`

## Test plan

- [ ] All 1012 tests pass (`pytest`)
- [ ] Coverage ≥ 90% (currently 99.35%)
- [ ] `pytest tests/core/test_wellness_orchestrator.py` — orchestrator flow
- [ ] `pytest tests/connectors/test_local_folder_wellness.py` — file storage round-trips
- [ ] `pytest tests/core/test_wellness_cache.py` — cache invalidation + atomic writes
- [ ] `pytest tests/connectors/test_garmin_wellness.py` — Garmin dispatch table
- [ ] `pytest tests/connectors/test_strava_wellness.py` — Strava snapshot serialisation