### PR TITLE
build: add uv build-system so the console script installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ default-groups = "all"
 module-name = ["app"]
 module-root = ""
 
+# Build the project with uv's backend so its console script (project.scripts) installs under uv.
+[build-system]
+requires = ["uv_build>=0.11,<0.12"]
+build-backend = "uv_build"
+
 [tool.ruff]
 line-length = 88
 # Lint target kept at py310 so the uv migration stays scoped to tooling; modernising to the

--- a/uv.lock
+++ b/uv.lock
@@ -1017,7 +1017,7 @@ wheels = [
 [[package]]
 name = "trainings-sync"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "garminconnect" },
     { name = "gpxpy" },


### PR DESCRIPTION
After the Poetry->uv migration, `uv sync` warned: *Skipping installation of entry points (`project.scripts`) ... because this project is not packaged*, so the `trainings-sync` command was not created.

Add a `[build-system]` using uv's build backend so the project is built and its console script installs and runs via `uv run trainings-sync`.