### PR TITLE
feat(gui): PySide6 desktop GUI for trainings-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            libgl1 libglib2.0-0 libdbus-1-3 \
+            libgl1 libegl1 libglib2.0-0 libdbus-1-3 \
             libfontconfig1 libxkbcommon0
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,20 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: "3.14"
+      - name: Install Qt system libraries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libgl1 libglib2.0-0 libdbus-1-3 \
+            libfontconfig1 libxkbcommon0
       - name: Install dependencies
         run: uv sync
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ It stores everything in a fixed location under your home directory:
   cache/             # activity + wellness cache and sync.log
 ```
 
+The window has three tabs, ordered by how often you use them: **Sync**
+(the default landing tab), **Configuration**, and **Credentials**. If you
+already have CLI config/creds files (for example under `config/`), you can
+import them instead of re-entering everything - see the *Load from file...*
+buttons below. The walkthrough that follows is in first-time setup order.
+
 ### Credentials tab
 
 Manage the service logins used by the connectors. Use **Add** / **Edit** /
@@ -239,6 +245,9 @@ table.
 - **Garmin:** *Login* is your Garmin email, *Password* is your Garmin password.
 - **Strava:** *Login* is your Client Secret, *Password / Token* is the refresh
   token (see [Getting Strava credentials](#getting-strava-credentials) above).
+
+**Load from file...** imports an existing CLI-style credentials JSON file (the
+same format as `--creds-json`), replacing the current list.
 
 ### Configuration tab
 
@@ -254,6 +263,10 @@ Build the sync configuration visually:
   destinations, both chosen from the connectors you defined.
 - **Options** - optional custom start/end dates, *Force re-download* (ignore the
   cache), and *Skip wellness sync*. Click **Save configuration** to persist.
+
+**Load from file...** imports an existing config JSON file - both the GUI's own
+`config.json` and a CLI config file work (the CLI-only `cache_dir` field is
+ignored). It replaces the whole configuration.
 
 ### Sync tab
 

--- a/README.md
+++ b/README.md
@@ -237,44 +237,46 @@ buttons below. The walkthrough that follows is in first-time setup order.
 
 ### Credentials tab
 
-Manage the service logins used by the connectors. Use **Add** / **Edit** /
-**Delete** to maintain the list. Each entry has a *Service*, *URL*, *Login*,
-and *Password / Token*. Passwords are hidden while typing and masked in the
-table.
+Manage the accounts the connectors use. Use **Add** / **Edit** / **Delete** to
+maintain the list. Each account has a *Service*, *URL*, *Login*, and a
+per-account **source** shown in the table:
 
-- **Garmin:** *Login* is your Garmin email, *Password* is your Garmin password.
-- **Strava:** *Login* is your Client Secret, *Password / Token* is the refresh
-  token (see [Getting Strava credentials](#getting-strava-credentials) above).
+- **Enter manually** - you type the *Password / Token* in; it is stored in
+  `credentials.json` (hidden while typing, masked in the table).
+- **From KeePass file** - you point the account at a `.kdbx` file instead of
+  typing a password. The entry is matched in the database by *URL* (and *Login*,
+  if set); only the file path is stored, never the KeePass master password.
+
+For Garmin, *Login* is your Garmin email and the password is your Garmin
+password. For Strava, *Login* is your Client Secret and the password is the
+refresh token (see [Getting Strava credentials](#getting-strava-credentials)).
+Strava must use a **manual** account - its refresh token is rotated and written
+back, which a read-only KeePass file cannot store.
 
 **Load from file...** imports an existing CLI-style credentials JSON file (the
-same format as `--creds-json`), replacing the current list.
+same format as `--creds-json`) as manual accounts, replacing the current list.
 
-**Credential source.** At the top of the tab you can choose where the sync
-reads credentials from:
-
-- **Built-in JSON store** (default) - the table described above, managed in the
-  GUI and saved to `credentials.json`.
-- **KeePass database** - point the sync at an external `.kdbx` file. Entries are
-  matched by URL (and login, if set) and are edited in KeePass itself, so the
-  table is disabled in this mode. The **master password is asked for each time
-  you run a sync** and is never stored on disk. As with the CLI's
-  `--creds-keepass`, Strava is not supported with KeePass (its refresh token
-  cannot be written back); use the JSON store for Strava.
+A credential that is referenced by a connector cannot be deleted; the GUI names
+the connectors so you can detach it first.
 
 ### Configuration tab
 
 Build the sync configuration visually:
 
-- **Connectors** - add each data source/destination. Pick a type (`garmin`,
-  `strava`, or `local_folder`); the dialog shows only the fields that type
-  needs. For Garmin/Strava the *Service* and *URL* must match a credentials
-  entry; for a local folder just provide the path. Deleting a connector also
-  removes it from any sync group that referenced it.
+- **Connectors** - add each data source/destination. Give it a **Name** (used to
+  reference it from sync groups) and a **Type** (`garmin`, `strava`, or
+  `local_folder`). For Garmin/Strava pick a **Credentials** account from the
+  dropdown (populated from the Credentials tab) - its URL and login come from
+  that account. For a local folder just provide the path. A connector used by a
+  sync group cannot be deleted until you remove it from those groups.
 - **Sync Groups** - define what syncs where. Add sources (each with a priority;
   higher priority wins when the same activity exists in several sources) and
   destinations, both chosen from the connectors you defined.
 - **Options** - optional custom start/end dates, *Force re-download* (ignore the
   cache), and *Skip wellness sync*. Click **Save configuration** to persist.
+
+When a sync run uses any KeePass-backed account, the GUI asks for each `.kdbx`
+file's master password once, at **Run Sync** - the passwords are never stored.
 
 **Load from file...** imports an existing config JSON file - both the GUI's own
 `config.json` and a CLI config file work (the CLI-only `cache_dir` field is

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ table.
 **Load from file...** imports an existing CLI-style credentials JSON file (the
 same format as `--creds-json`), replacing the current list.
 
+**Credential source.** At the top of the tab you can choose where the sync
+reads credentials from:
+
+- **Built-in JSON store** (default) - the table described above, managed in the
+  GUI and saved to `credentials.json`.
+- **KeePass database** - point the sync at an external `.kdbx` file. Entries are
+  matched by URL (and login, if set) and are edited in KeePass itself, so the
+  table is disabled in this mode. The **master password is asked for each time
+  you run a sync** and is never stored on disk. As with the CLI's
+  `--creds-keepass`, Strava is not supported with KeePass (its refresh token
+  cannot be written back); use the JSON store for Strava.
+
 ### Configuration tab
 
 Build the sync configuration visually:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,70 @@ request:
 When a limit is reached, the sync automatically pauses and resumes after the window resets. Your app's
 current limits are shown at [strava.com/settings/api](https://www.strava.com/settings/api).
 
+## Desktop GUI
+
+If you would rather not edit JSON config files by hand, a desktop GUI is
+available. It exposes the same functionality as the CLI - credentials, sync
+configuration, and running a sync with live progress - through a windowed
+interface.
+
+### Launching
+
+```bash
+uv run trainings-sync-gui
+```
+
+On Linux the GUI needs a few Qt system libraries. On a headless or minimal
+install run:
+
+```bash
+sudo apt-get install -y libgl1 libegl1 libglib2.0-0 libdbus-1-3 \
+  libfontconfig1 libxkbcommon0
+```
+
+Unlike the CLI, the GUI does not take `--config` / `--creds-json` arguments.
+It stores everything in a fixed location under your home directory:
+
+```
+~/.config/trainings-sync/
+  config.json        # connectors, sync groups, options
+  credentials.json   # service credentials (plain JSON, same format as the CLI)
+  cache/             # activity + wellness cache and sync.log
+```
+
+### Credentials tab
+
+Manage the service logins used by the connectors. Use **Add** / **Edit** /
+**Delete** to maintain the list. Each entry has a *Service*, *URL*, *Login*,
+and *Password / Token*. Passwords are hidden while typing and masked in the
+table.
+
+- **Garmin:** *Login* is your Garmin email, *Password* is your Garmin password.
+- **Strava:** *Login* is your Client Secret, *Password / Token* is the refresh
+  token (see [Getting Strava credentials](#getting-strava-credentials) above).
+
+### Configuration tab
+
+Build the sync configuration visually:
+
+- **Connectors** - add each data source/destination. Pick a type (`garmin`,
+  `strava`, or `local_folder`); the dialog shows only the fields that type
+  needs. For Garmin/Strava the *Service* and *URL* must match a credentials
+  entry; for a local folder just provide the path. Deleting a connector also
+  removes it from any sync group that referenced it.
+- **Sync Groups** - define what syncs where. Add sources (each with a priority;
+  higher priority wins when the same activity exists in several sources) and
+  destinations, both chosen from the connectors you defined.
+- **Options** - optional custom start/end dates, *Force re-download* (ignore the
+  cache), and *Skip wellness sync*. Click **Save configuration** to persist.
+
+### Sync tab
+
+Click **Run Sync** to start. A progress bar appears for every task, mirroring
+the console output. If the run fails, the error is shown in a dialog; use
+**Show full log** to open the full `sync.log` for the traceback and details.
+The sync runs in the background, so the window stays responsive.
+
 ## Wellness data sync
 
 In addition to training activities, the tool automatically syncs wellness data from each configured service to local folder destinations. This happens on every run by default (use `--skip-wellness` to disable).

--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ buttons below. The walkthrough that follows is in first-time setup order.
 ### Credentials tab
 
 Manage the accounts the connectors use. Use **Add** / **Edit** / **Delete** to
-maintain the list. Each account has a *Service*, *URL*, *Login*, and a
-per-account **source** shown in the table:
+maintain the list. Each account has an *Account name*, a *URL* (chosen from the
+known service endpoints or typed in), a *Login*, and a per-account **source**
+shown in the table:
 
 - **Enter manually** - you type the *Password / Token* in; it is stored in
   `credentials.json` (hidden while typing, masked in the table).
@@ -267,8 +268,9 @@ Build the sync configuration visually:
   reference it from sync groups) and a **Type** (`garmin`, `strava`, or
   `local_folder`). For Garmin/Strava pick a **Credentials** account from the
   dropdown (populated from the Credentials tab) - its URL and login come from
-  that account. For a local folder just provide the path. A connector used by a
-  sync group cannot be deleted until you remove it from those groups.
+  that account. For a local folder pick the directory with **Browse...** (or type
+  the path). A connector used by a sync group cannot be deleted until you remove
+  it from those groups.
 - **Sync Groups** - define what syncs where. Add sources (each with a priority;
   higher priority wins when the same activity exists in several sources) and
   destinations, both chosen from the connectors you defined.

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -223,8 +223,11 @@ class TaskRow(QWidget):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 2, 4, 2)
 
-        self._status = QLabel("[~]")  # [~]
-        self._status.setFixedWidth(24)
+        self._status = QLabel("[~]")
+        # Size to the widest tag ("[OK]") so the closing bracket is never
+        # clipped, regardless of the platform font.
+        ok_width = self._status.fontMetrics().horizontalAdvance("[OK]")
+        self._status.setFixedWidth(ok_width + 8)
         layout.addWidget(self._status)
 
         self._label = QLabel(name)

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -371,7 +371,7 @@ class CredentialDialog(QDialog):
         self._url.addItems(_KNOWN_CREDENTIAL_URLS)
         self._url.setCurrentText(entry.url if entry else "")
         self._login = QLineEdit(entry.login if entry else "")
-        form.addRow("Service:", self._service)
+        form.addRow("Account name:", self._service)
         form.addRow("URL:", self._url)
         form.addRow("Login:", self._login)
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -314,6 +314,13 @@ class CredentialDialog(QDialog):
         btns.rejected.connect(self.reject)
         form.addRow(btns)
 
+        self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
+        self._service.textChanged.connect(self._validate)
+        self._validate()
+
+    def _validate(self) -> None:
+        self._ok_btn.setEnabled(bool(self._service.text().strip()))
+
     def result_entry(self) -> CredentialEntry:
         return CredentialEntry(
             service=self._service.text().strip(),
@@ -461,8 +468,15 @@ class ConnectorDialog(QDialog):
         btns.rejected.connect(self.reject)
         root.addWidget(btns)
 
+        self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
+        self._id.textChanged.connect(self._validate)
+        self._validate()
+
         self._type.currentTextChanged.connect(self._on_type_changed)
         self._on_type_changed(self._type.currentText())
+
+    def _validate(self) -> None:
+        self._ok_btn.setEnabled(bool(self._id.text().strip()))
 
     def _on_type_changed(self, t: str) -> None:
         self._cred_box.setVisible(t in ("garmin", "strava"))
@@ -556,6 +570,13 @@ class SyncGroupDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         root.addWidget(btns)
+
+        self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
+        self._id.textChanged.connect(self._validate)
+        self._validate()
+
+    def _validate(self) -> None:
+        self._ok_btn.setEnabled(bool(self._id.text().strip()))
 
     @staticmethod
     def _make_source_item(cid: str, priority: int) -> QListWidgetItem:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -709,13 +709,6 @@ class ConfigTab(QWidget):
         self._start_date = QDateEdit()
         self._start_date.setCalendarPopup(True)
         self._start_date.setDisplayFormat("yyyy-MM-dd")
-        if self._config.start:
-            d = date.fromisoformat(self._config.start)
-            self._start_date.setDate(QDate(d.year, d.month, d.day))
-            self._use_start.setChecked(True)
-        else:
-            self._start_date.setDate(QDate.currentDate())
-        self._start_date.setEnabled(self._use_start.isChecked())
         self._use_start.toggled.connect(self._start_date.setEnabled)
         date_row_start.addWidget(self._use_start)
         date_row_start.addWidget(self._start_date)
@@ -726,35 +719,73 @@ class ConfigTab(QWidget):
         self._end_date = QDateEdit()
         self._end_date.setCalendarPopup(True)
         self._end_date.setDisplayFormat("yyyy-MM-dd")
-        if self._config.end:
-            d2 = date.fromisoformat(self._config.end)
-            self._end_date.setDate(QDate(d2.year, d2.month, d2.day))
-            self._use_end.setChecked(True)
-        else:
-            self._end_date.setDate(QDate.currentDate())
-        self._end_date.setEnabled(self._use_end.isChecked())
         self._use_end.toggled.connect(self._end_date.setEnabled)
         date_row_end.addWidget(self._use_end)
         date_row_end.addWidget(self._end_date)
         opt_layout.addRow("End:", date_row_end)
 
         self._force_cb = QCheckBox("Force re-download (ignore cache)")
-        self._force_cb.setChecked(self._config.force)
         opt_layout.addRow(self._force_cb)
 
         self._skip_wellness_cb = QCheckBox("Skip wellness sync")
-        self._skip_wellness_cb.setChecked(self._config.skip_wellness)
         opt_layout.addRow(self._skip_wellness_cb)
 
+        btn_box = QHBoxLayout()
         save_btn = QPushButton("Save configuration")
         save_btn.clicked.connect(self._save)
-        opt_layout.addRow(save_btn)
+        self._load_btn = QPushButton("Load from file...")
+        self._load_btn.clicked.connect(self._load_from_file)
+        btn_box.addWidget(save_btn)
+        btn_box.addWidget(self._load_btn)
+        btn_box.addStretch()
+        opt_layout.addRow(btn_box)
 
         root.addWidget(opt_box)
         root.addStretch()
 
+        self._reload_view()
+
+    def _reload_view(self) -> None:
         self._refresh_connector_list()
         self._refresh_group_list()
+        self._apply_options_from_config()
+
+    def _apply_options_from_config(self) -> None:
+        if self._config.start:
+            d = date.fromisoformat(self._config.start)
+            self._start_date.setDate(QDate(d.year, d.month, d.day))
+            self._use_start.setChecked(True)
+        else:
+            self._start_date.setDate(QDate.currentDate())
+            self._use_start.setChecked(False)
+        self._start_date.setEnabled(self._use_start.isChecked())
+        if self._config.end:
+            d2 = date.fromisoformat(self._config.end)
+            self._end_date.setDate(QDate(d2.year, d2.month, d2.day))
+            self._use_end.setChecked(True)
+        else:
+            self._end_date.setDate(QDate.currentDate())
+            self._use_end.setChecked(False)
+        self._end_date.setEnabled(self._use_end.isChecked())
+        self._force_cb.setChecked(self._config.force)
+        self._skip_wellness_cb.setChecked(self._config.skip_wellness)
+
+    def _load_from_file(self) -> None:
+        path_str, _ = QFileDialog.getOpenFileName(
+            self, "Load configuration", "", "JSON files (*.json);;All files (*)"
+        )
+        if not path_str:
+            return
+        try:
+            config = self._store.load_gui_config_from(Path(path_str))
+        except (OSError, ValueError, KeyError) as exc:
+            QMessageBox.critical(
+                self, "Load failed", f"Could not load configuration:\n{exc}"
+            )
+            return
+        self._config = config
+        self._store.save_gui_config(self._config)
+        self._reload_view()
 
     # ------------------------------------------------------------------
     # Connectors

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -86,11 +86,13 @@ class SyncWorker(QThread):
         config_store: ConfigStore,
         gui_config: GuiConfig,
         renderer: GuiRenderer,
+        keepass_password: str | None = None,
     ) -> None:
         super().__init__()
         self._store = config_store
         self._gui_config = gui_config
         self._renderer = renderer
+        self._keepass_password = keepass_password
 
     def run(self) -> None:
         ts_start = datetime.now().astimezone().isoformat(timespec="seconds")
@@ -122,9 +124,7 @@ class SyncWorker(QThread):
         sync_logger.run_start(start=start, end=end, force=force)
         try:
             tracker = TaskTracker(self._renderer, sync_logger=sync_logger)
-            provider = JsonFileProvider(
-                path=self._store.credentials_path, tracker=tracker
-            )
+            provider = self._build_provider(app_config, tracker)
 
             strava_cred_map = {
                 c.id: c.credential
@@ -135,10 +135,11 @@ class SyncWorker(QThread):
             def _on_token_refresh(
                 connector_id: str, new_creds: object, _label: str
             ) -> None:
-                provider.update_refresh_token(
-                    strava_cred_map[connector_id],
-                    new_creds.refresh_token,  # type: ignore[attr-defined]
-                )
+                if isinstance(provider, JsonFileProvider):
+                    provider.update_refresh_token(
+                        strava_cred_map[connector_id],
+                        new_creds.refresh_token,  # type: ignore[attr-defined]
+                    )
 
             cache = ActivityCache(app_config.cache_dir)
             cache.load()
@@ -214,6 +215,28 @@ class SyncWorker(QThread):
             await wellness_orch.run(start, end, force=self._gui_config.force)
         except Exception:  # noqa: S110
             pass  # wellness failures are non-fatal, mirroring CLI behaviour
+
+    def _build_provider(
+        self, app_config: AppConfig, tracker: TaskTracker
+    ) -> CredentialProvider:
+        from app.core.config import StravaConnectorConfig
+        from app.credentials.json_file import JsonFileProvider
+
+        source = self._store.load_credential_source()
+        if source.source == "keepass":
+            from app.credentials.keepass import KeePassProvider
+
+            if any(isinstance(c, StravaConnectorConfig) for c in app_config.connectors):
+                raise ValueError(
+                    "KeePass credential source does not support Strava connectors; "
+                    "use the built-in JSON store for Strava"
+                )
+            return KeePassProvider(
+                path=Path(source.keepass_path).expanduser(),
+                password=self._keepass_password or "",
+                tracker=tracker,
+            )
+        return JsonFileProvider(path=self._store.credentials_path, tracker=tracker)
 
 
 def _parse_date_or_default(value: str, default: date) -> date:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -788,7 +788,8 @@ class SyncGroupDialog(QDialog):
     def _add_source(self) -> None:
         cid = self._src_add_combo.currentText()
         pri = self._src_priority.value()
-        if cid and cid not in self._source_ids():
+        # A connector cannot be both a source and a destination of one group.
+        if cid and cid not in self._source_ids() and cid not in self._destination_ids():
             self._sources_widget.addItem(self._make_source_item(cid, pri))
 
     def _remove_source(self) -> None:
@@ -798,7 +799,7 @@ class SyncGroupDialog(QDialog):
 
     def _add_destination(self) -> None:
         cid = self._dst_add_combo.currentText()
-        if cid and cid not in self._destination_ids():
+        if cid and cid not in self._destination_ids() and cid not in self._source_ids():
             self._destinations_widget.addItem(cid)
 
     def _remove_destination(self) -> None:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -394,6 +394,7 @@ class CredentialDialog(QDialog):
 
         self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
         self._service.textChanged.connect(self._validate)
+        self._keepass_path.textChanged.connect(self._validate)
         self._keepass_radio.toggled.connect(self._on_source_changed)
         self._keepass_browse.clicked.connect(self._browse_keepass)
 
@@ -418,7 +419,10 @@ class CredentialDialog(QDialog):
             self._keepass_path.setText(path_str)
 
     def _validate(self) -> None:
-        self._ok_btn.setEnabled(bool(self._service.text().strip()))
+        ok = bool(self._service.text().strip())
+        if self._keepass_radio.isChecked():
+            ok = ok and bool(self._keepass_path.text().strip())
+        self._ok_btn.setEnabled(ok)
 
     def result_entry(self) -> CredentialEntry:
         if self._keepass_radio.isChecked():

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -1049,10 +1049,21 @@ class ConfigTab(QWidget):
             dst_str = ", ".join(g.destinations)
             self._grp_list.addItem(f"{g.id}  [{src_str}] -> [{dst_str}]")
 
+    def _group_name_taken(self, name: str, exclude_index: int | None) -> bool:
+        return any(
+            g.id == name
+            for i, g in enumerate(self._config.sync_groups)
+            if i != exclude_index
+        )
+
     def _add_group(self) -> None:
         dlg = SyncGroupDialog(connector_ids=self._connector_ids(), parent=self)
         if dlg.exec() == QDialog.DialogCode.Accepted:
-            self._config.sync_groups.append(dlg.result_entry())
+            entry = dlg.result_entry()
+            if self._group_name_taken(entry.id, exclude_index=None):
+                self._warn_duplicate_group(entry.id)
+                return
+            self._config.sync_groups.append(entry)
             self._store.save_gui_config(self._config)
             self._refresh_group_list()
 
@@ -1066,9 +1077,20 @@ class ConfigTab(QWidget):
             parent=self,
         )
         if dlg.exec() == QDialog.DialogCode.Accepted:
-            self._config.sync_groups[row] = dlg.result_entry()
+            entry = dlg.result_entry()
+            if self._group_name_taken(entry.id, exclude_index=row):
+                self._warn_duplicate_group(entry.id)
+                return
+            self._config.sync_groups[row] = entry
             self._store.save_gui_config(self._config)
             self._refresh_group_list()
+
+    def _warn_duplicate_group(self, name: str) -> None:
+        QMessageBox.warning(
+            self,
+            "Duplicate group",
+            f"A sync group named {name!r} already exists. Group names must be unique.",
+        )
 
     def _delete_group(self) -> None:
         row = self._grp_list.currentRow()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -220,6 +220,15 @@ def _parse_date_or_default(value: str, default: date) -> date:
     return default
 
 
+def _editable_combo(values: list[str], current: str) -> QComboBox:
+    """A combo box pre-filled with known values that still accepts free text."""
+    combo = QComboBox()
+    combo.setEditable(True)
+    combo.addItems(values)
+    combo.setCurrentText(current)
+    return combo
+
+
 # ---------------------------------------------------------------------------
 # TaskRow - one row per sync task shown in the Sync tab
 # ---------------------------------------------------------------------------
@@ -451,11 +460,13 @@ class ConnectorDialog(QDialog):
     def __init__(
         self,
         entry: ConnectorEntry | None = None,
+        credentials: list[CredentialEntry] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Add Connector" if entry is None else "Edit Connector")
         self.setMinimumWidth(440)
+        self._credentials = credentials or []
 
         root = QVBoxLayout(self)
         form = QFormLayout()
@@ -471,12 +482,25 @@ class ConnectorDialog(QDialog):
                 self._type.setCurrentIndex(idx)
         form.addRow("Type:", self._type)
 
-        # Credential fields (garmin + strava)
+        # Credential fields (garmin + strava). These are editable combo boxes
+        # pre-populated with the accounts configured on the Credentials tab, so
+        # the user can pick a known account or still type a custom value.
         self._cred_box = QGroupBox("Credentials")
         cred_form = QFormLayout(self._cred_box)
-        self._cred_service = QLineEdit(entry.credential_service if entry else "")
-        self._cred_url = QLineEdit(entry.credential_url if entry else "")
-        self._cred_login = QLineEdit(entry.credential_login if entry else "")
+        self._cred_service = _editable_combo(
+            sorted({c.service for c in self._credentials if c.service}),
+            entry.credential_service if entry else "",
+        )
+        self._cred_url = _editable_combo(
+            sorted({c.url for c in self._credentials if c.url}),
+            entry.credential_url if entry else "",
+        )
+        self._cred_login = _editable_combo(
+            sorted({c.login for c in self._credentials if c.login}),
+            entry.credential_login if entry else "",
+        )
+        # Selecting a known service auto-fills that account's URL and login.
+        self._cred_service.currentTextChanged.connect(self._on_service_changed)
         cred_form.addRow("Service:", self._cred_service)
         cred_form.addRow("URL:", self._cred_url)
         cred_form.addRow("Login (optional):", self._cred_login)
@@ -520,14 +544,22 @@ class ConnectorDialog(QDialog):
         self._client_id_spin.setVisible(t == "strava")
         self._folder_box.setVisible(t == "local_folder")
 
+    def _on_service_changed(self, service: str) -> None:
+        match = next(
+            (c for c in self._credentials if c.service == service and c.service), None
+        )
+        if match is not None:
+            self._cred_url.setCurrentText(match.url)
+            self._cred_login.setCurrentText(match.login)
+
     def result_entry(self) -> ConnectorEntry:
         t = self._type.currentText()
         return ConnectorEntry(
             id=self._id.text().strip(),
             type=t,
-            credential_service=self._cred_service.text().strip(),
-            credential_url=self._cred_url.text().strip(),
-            credential_login=self._cred_login.text().strip(),
+            credential_service=self._cred_service.currentText().strip(),
+            credential_url=self._cred_url.currentText().strip(),
+            credential_login=self._cred_login.currentText().strip(),
             client_id=self._client_id_spin.value() if t == "strava" else 0,
             folder=self._folder.text().strip() if t == "local_folder" else "",
         )
@@ -813,7 +845,7 @@ class ConfigTab(QWidget):
             self._conn_list.addItem(f"[{c.type}] {c.id}")
 
     def _add_connector(self) -> None:
-        dlg = ConnectorDialog(parent=self)
+        dlg = ConnectorDialog(credentials=self._store.load_credentials(), parent=self)
         if dlg.exec() == QDialog.DialogCode.Accepted:
             self._config.connectors.append(dlg.result_entry())
             self._store.save_gui_config(self._config)
@@ -823,7 +855,11 @@ class ConfigTab(QWidget):
         row = self._conn_list.currentRow()
         if row < 0:
             return
-        dlg = ConnectorDialog(entry=self._config.connectors[row], parent=self)
+        dlg = ConnectorDialog(
+            entry=self._config.connectors[row],
+            credentials=self._store.load_credentials(),
+            parent=self,
+        )
         if dlg.exec() == QDialog.DialogCode.Accepted:
             self._config.connectors[row] = dlg.result_entry()
             self._store.save_gui_config(self._config)

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -40,6 +40,7 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QHeaderView,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QListWidget,
@@ -1122,6 +1123,12 @@ class SyncTab(QWidget):
     def _run_sync(self) -> None:
         gui_config = self._config_tab.current_config()
 
+        # When credentials come from KeePass, ask for the master password up
+        # front (on the GUI thread) - it is never stored anywhere.
+        proceed, keepass_password = self._prompt_keepass_password()
+        if not proceed:
+            return
+
         # Clear previous task rows
         while self._task_layout.count() > 1:  # keep the trailing stretch
             item = self._task_layout.takeAt(0)
@@ -1139,13 +1146,34 @@ class SyncTab(QWidget):
         sigs.task_failed.connect(self._on_task_failed)
         sigs.total_updated.connect(self._on_total_updated)
 
-        self._worker = SyncWorker(self._store, gui_config, renderer)
+        self._worker = SyncWorker(
+            self._store, gui_config, renderer, keepass_password=keepass_password
+        )
         self._worker.started_ts.connect(self._on_started)
         self._worker.finished_ts.connect(self._on_finished)
         self._worker.error_occurred.connect(self._on_error)
 
         self._run_btn.setEnabled(False)
         self._worker.start()
+
+    def _prompt_keepass_password(self) -> tuple[bool, str | None]:
+        """Return (proceed, password).
+
+        ``password`` is None when the source is not KeePass; ``proceed`` is
+        False only when the user cancels the master-password prompt.
+        """
+        source = self._store.load_credential_source()
+        if source.source != "keepass":
+            return True, None
+        password, ok = QInputDialog.getText(
+            self,
+            "KeePass master password",
+            f"Master password for {source.keepass_path}:",
+            QLineEdit.EchoMode.Password,
+        )
+        if not ok:
+            return False, None
+        return True, password
 
     def _on_started(self, ts: str) -> None:
         self._status.setText(f"Sync started: {ts}")

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -29,6 +29,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QListWidget,
+    QListWidgetItem,
     QMainWindow,
     QMessageBox,
     QProgressBar,
@@ -493,9 +494,6 @@ class SyncGroupDialog(QDialog):
         src_box = QGroupBox("Sources (connector id : priority)")
         src_layout = QVBoxLayout(src_box)
         self._sources_widget = QListWidget()
-        if entry:
-            for s in entry.sources:
-                self._sources_widget.addItem(f"{s.id}:{s.priority}")
         src_layout.addWidget(self._sources_widget)
         src_btn_row = QHBoxLayout()
         self._src_add_combo = QComboBox()
@@ -513,6 +511,11 @@ class SyncGroupDialog(QDialog):
         src_btn_row.addWidget(self._src_add_btn)
         src_btn_row.addWidget(self._src_del_btn)
         src_layout.addLayout(src_btn_row)
+
+        if entry:
+            for s in entry.sources:
+                self._sources_widget.addItem(self._make_source_item(s.id, s.priority))
+
         root.addWidget(src_box)
 
         # Destinations
@@ -543,11 +546,17 @@ class SyncGroupDialog(QDialog):
         btns.rejected.connect(self.reject)
         root.addWidget(btns)
 
+    @staticmethod
+    def _make_source_item(cid: str, priority: int) -> QListWidgetItem:
+        item = QListWidgetItem(f"{cid} : {priority}")
+        item.setData(Qt.ItemDataRole.UserRole, (cid, priority))
+        return item
+
     def _add_source(self) -> None:
         cid = self._src_add_combo.currentText()
         pri = self._src_priority.value()
         if cid:
-            self._sources_widget.addItem(f"{cid}:{pri}")
+            self._sources_widget.addItem(self._make_source_item(cid, pri))
 
     def _remove_source(self) -> None:
         row = self._sources_widget.currentRow()
@@ -567,11 +576,8 @@ class SyncGroupDialog(QDialog):
     def result_entry(self) -> SyncGroupEntry:
         sources = []
         for i in range(self._sources_widget.count()):
-            text = self._sources_widget.item(i).text()
-            cid, _, pri_str = text.partition(":")
-            sources.append(
-                GroupSourceEntry(id=cid.strip(), priority=int(pri_str or "1"))
-            )
+            cid, priority = self._sources_widget.item(i).data(Qt.ItemDataRole.UserRole)
+            sources.append(GroupSourceEntry(id=cid, priority=priority))
         destinations = [
             self._destinations_widget.item(i).text()
             for i in range(self._destinations_widget.count())

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -526,6 +526,17 @@ class CredentialsTab(QWidget):
         if row < 0:
             return
         entry = self._entries[row]
+        using = self._connectors_using_credential(entry)
+        if using:
+            connectors = ", ".join(repr(c) for c in using)
+            QMessageBox.warning(
+                self,
+                "Credential in use",
+                f"Credential {entry.service!r} is used by connector(s): "
+                f"{connectors}.\n\nRemove it from those connectors before "
+                "deleting the credential.",
+            )
+            return
         reply = QMessageBox.question(
             self,
             "Delete credential",
@@ -535,6 +546,22 @@ class CredentialsTab(QWidget):
             self._entries.pop(row)
             self._store.save_credentials(self._entries)
             self._refresh_table()
+
+    def _connectors_using_credential(self, cred: CredentialEntry) -> list[str]:
+        from app.gui.credential_provider import find_credential
+
+        connectors = self._store.load_gui_config().connectors
+        return [
+            c.id
+            for c in connectors
+            if find_credential(
+                [cred],
+                c.credential_service,
+                c.credential_url,
+                c.credential_login or None,
+            )
+            is not None
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -341,20 +341,42 @@ class CredentialDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Add Credential" if entry is None else "Edit Credential")
-        self.setMinimumWidth(420)
+        self.setMinimumWidth(440)
 
         form = QFormLayout(self)
+
+        # Per-credential source: type the secret in (manual) or resolve it from
+        # a KeePass .kdbx at sync time (the master password is never stored).
+        src_row = QHBoxLayout()
+        self._manual_radio = QRadioButton("Enter manually")
+        self._keepass_radio = QRadioButton("From KeePass file")
+        src_row.addWidget(self._manual_radio)
+        src_row.addWidget(self._keepass_radio)
+        src_row.addStretch()
+        form.addRow("Source:", src_row)
 
         self._service = QLineEdit(entry.service if entry else "")
         self._url = QLineEdit(entry.url if entry else "")
         self._login = QLineEdit(entry.login if entry else "")
-        self._password = QLineEdit(entry.password if entry else "")
-        self._password.setEchoMode(QLineEdit.EchoMode.Password)
-
         form.addRow("Service:", self._service)
         form.addRow("URL:", self._url)
         form.addRow("Login:", self._login)
-        form.addRow("Password / Token:", self._password)
+
+        self._password = QLineEdit(entry.password if entry else "")
+        self._password.setEchoMode(QLineEdit.EchoMode.Password)
+        self._password_label = QLabel("Password / Token:")
+        form.addRow(self._password_label, self._password)
+
+        kp_row = QHBoxLayout()
+        self._keepass_path = QLineEdit(entry.keepass_path if entry else "")
+        self._keepass_path.setPlaceholderText("Path to .kdbx file")
+        self._keepass_browse = QPushButton("Browse...")
+        kp_row.addWidget(self._keepass_path)
+        kp_row.addWidget(self._keepass_browse)
+        self._keepass_row = QWidget()
+        self._keepass_row.setLayout(kp_row)
+        self._keepass_label = QLabel("KeePass file:")
+        form.addRow(self._keepass_label, self._keepass_row)
 
         hint = QLabel("For Strava: login = client_secret, password = refresh_token")
         hint.setWordWrap(True)
@@ -369,17 +391,47 @@ class CredentialDialog(QDialog):
 
         self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
         self._service.textChanged.connect(self._validate)
+        self._keepass_radio.toggled.connect(self._on_source_changed)
+        self._keepass_browse.clicked.connect(self._browse_keepass)
+
+        is_keepass = entry is not None and entry.source == "keepass"
+        self._keepass_radio.setChecked(is_keepass)
+        self._manual_radio.setChecked(not is_keepass)
+        self._on_source_changed()
+
+    def _on_source_changed(self) -> None:
+        is_keepass = self._keepass_radio.isChecked()
+        self._password.setVisible(not is_keepass)
+        self._password_label.setVisible(not is_keepass)
+        self._keepass_row.setVisible(is_keepass)
+        self._keepass_label.setVisible(is_keepass)
         self._validate()
+
+    def _browse_keepass(self) -> None:
+        path_str, _ = QFileDialog.getOpenFileName(
+            self, "Select KeePass database", "", "KeePass (*.kdbx);;All files (*)"
+        )
+        if path_str:
+            self._keepass_path.setText(path_str)
 
     def _validate(self) -> None:
         self._ok_btn.setEnabled(bool(self._service.text().strip()))
 
     def result_entry(self) -> CredentialEntry:
+        if self._keepass_radio.isChecked():
+            return CredentialEntry(
+                service=self._service.text().strip(),
+                url=self._url.text().strip(),
+                login=self._login.text().strip(),
+                source="keepass",
+                keepass_path=self._keepass_path.text().strip(),
+            )
         return CredentialEntry(
             service=self._service.text().strip(),
             url=self._url.text().strip(),
             login=self._login.text().strip(),
             password=self._password.text(),
+            source="manual",
         )
 
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -87,13 +87,13 @@ class SyncWorker(QThread):
         config_store: ConfigStore,
         gui_config: GuiConfig,
         renderer: GuiRenderer,
-        keepass_password: str | None = None,
+        keepass_passwords: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._store = config_store
         self._gui_config = gui_config
         self._renderer = renderer
-        self._keepass_password = keepass_password
+        self._keepass_passwords = keepass_passwords or {}
 
     def run(self) -> None:
         ts_start = datetime.now().astimezone().isoformat(timespec="seconds")
@@ -110,7 +110,7 @@ class SyncWorker(QThread):
         from app.core.config import StravaConnectorConfig
         from app.core.connector_factory import build_connectors
         from app.core.orchestrator import SyncOrchestrator
-        from app.credentials.json_file import JsonFileProvider
+        from app.gui.credential_provider import GuiCredentialProvider
         from app.tracking.sync_logger import SyncLogger
         from app.tracking.tracker import TaskTracker
 
@@ -136,7 +136,7 @@ class SyncWorker(QThread):
             def _on_token_refresh(
                 connector_id: str, new_creds: object, _label: str
             ) -> None:
-                if isinstance(provider, JsonFileProvider):
+                if isinstance(provider, GuiCredentialProvider):
                     provider.update_refresh_token(
                         strava_cred_map[connector_id],
                         new_creds.refresh_token,  # type: ignore[attr-defined]
@@ -221,23 +221,36 @@ class SyncWorker(QThread):
         self, app_config: AppConfig, tracker: TaskTracker
     ) -> CredentialProvider:
         from app.core.config import StravaConnectorConfig
-        from app.credentials.json_file import JsonFileProvider
+        from app.gui.credential_provider import (
+            GuiCredentialProvider,
+            find_credential,
+        )
 
-        source = self._store.load_credential_source()
-        if source.source == "keepass":
-            from app.credentials.keepass import KeePassProvider
+        entries = self._store.load_credentials()
 
-            if any(isinstance(c, StravaConnectorConfig) for c in app_config.connectors):
-                raise ValueError(
-                    "KeePass credential source does not support Strava connectors; "
-                    "use the built-in JSON store for Strava"
+        # Strava refresh tokens are written back on rotation, which a read-only
+        # KeePass file cannot store - refuse that combination up front.
+        for cfg in app_config.connectors:
+            if isinstance(cfg, StravaConnectorConfig):
+                match = find_credential(
+                    entries,
+                    cfg.credential.service,
+                    cfg.credential.url,
+                    cfg.credential.login,
                 )
-            return KeePassProvider(
-                path=Path(source.keepass_path).expanduser(),
-                password=self._keepass_password or "",
-                tracker=tracker,
-            )
-        return JsonFileProvider(path=self._store.credentials_path, tracker=tracker)
+                if match is not None and match.source == "keepass":
+                    raise ValueError(
+                        f"connector {cfg.id!r}: Strava does not support KeePass "
+                        "credentials (its refresh token cannot be written back); "
+                        "use a manual credential for Strava"
+                    )
+
+        return GuiCredentialProvider(
+            entries,
+            self._keepass_passwords,
+            tracker,
+            on_manual_update=self._store.save_credentials,
+        )
 
 
 def _parse_date_or_default(value: str, default: date) -> date:
@@ -1138,9 +1151,9 @@ class SyncTab(QWidget):
     def _run_sync(self) -> None:
         gui_config = self._config_tab.current_config()
 
-        # When credentials come from KeePass, ask for the master password up
-        # front (on the GUI thread) - it is never stored anywhere.
-        proceed, keepass_password = self._prompt_keepass_password()
+        # Ask for each referenced KeePass file's master password up front (on
+        # the GUI thread) - the passwords are never stored anywhere.
+        proceed, keepass_passwords = self._prompt_keepass_passwords(gui_config)
         if not proceed:
             return
 
@@ -1162,7 +1175,7 @@ class SyncTab(QWidget):
         sigs.total_updated.connect(self._on_total_updated)
 
         self._worker = SyncWorker(
-            self._store, gui_config, renderer, keepass_password=keepass_password
+            self._store, gui_config, renderer, keepass_passwords=keepass_passwords
         )
         self._worker.started_ts.connect(self._on_started)
         self._worker.finished_ts.connect(self._on_finished)
@@ -1171,24 +1184,48 @@ class SyncTab(QWidget):
         self._run_btn.setEnabled(False)
         self._worker.start()
 
-    def _prompt_keepass_password(self) -> tuple[bool, str | None]:
-        """Return (proceed, password).
+    def _keepass_paths_in_use(self, gui_config: GuiConfig) -> list[str]:
+        """Distinct .kdbx paths of KeePass credentials referenced by connectors."""
+        from app.gui.credential_provider import find_credential
 
-        ``password`` is None when the source is not KeePass; ``proceed`` is
-        False only when the user cancels the master-password prompt.
+        entries = self._store.load_credentials()
+        paths: list[str] = []
+        for connector in gui_config.connectors:
+            match = find_credential(
+                entries,
+                connector.credential_service,
+                connector.credential_url,
+                connector.credential_login or None,
+            )
+            if (
+                match is not None
+                and match.source == "keepass"
+                and match.keepass_path
+                and match.keepass_path not in paths
+            ):
+                paths.append(match.keepass_path)
+        return paths
+
+    def _prompt_keepass_passwords(
+        self, gui_config: GuiConfig
+    ) -> tuple[bool, dict[str, str]]:
+        """Return (proceed, {kdbx_path: master_password}).
+
+        Prompts once per distinct .kdbx file in use; ``proceed`` is False only
+        when the user cancels a prompt.
         """
-        source = self._store.load_credential_source()
-        if source.source != "keepass":
-            return True, None
-        password, ok = QInputDialog.getText(
-            self,
-            "KeePass master password",
-            f"Master password for {source.keepass_path}:",
-            QLineEdit.EchoMode.Password,
-        )
-        if not ok:
-            return False, None
-        return True, password
+        passwords: dict[str, str] = {}
+        for path in self._keepass_paths_in_use(gui_config):
+            password, ok = QInputDialog.getText(
+                self,
+                "KeePass master password",
+                f"Master password for {path}:",
+                QLineEdit.EchoMode.Password,
+            )
+            if not ok:
+                return False, {}
+            passwords[path] = password
+        return True, passwords
 
     def _on_started(self, ts: str) -> None:
         self._status.setText(f"Sync started: {ts}")

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -104,58 +104,64 @@ class SyncWorker(QThread):
 
         sync_logger = SyncLogger(app_config.cache_dir / "sync.log")
         sync_logger.run_start(start=start, end=end, force=force)
-        tracker = TaskTracker(self._renderer, sync_logger=sync_logger)
-        provider = JsonFileProvider(path=self._store.credentials_path, tracker=tracker)
-
-        strava_cred_map = {
-            c.id: c.credential
-            for c in app_config.connectors
-            if isinstance(c, StravaConnectorConfig)
-        }
-
-        def _on_token_refresh(
-            connector_id: str, new_creds: object, _label: str
-        ) -> None:
-            provider.update_refresh_token(
-                strava_cred_map[connector_id],
-                new_creds.refresh_token,  # type: ignore[attr-defined]
+        try:
+            tracker = TaskTracker(self._renderer, sync_logger=sync_logger)
+            provider = JsonFileProvider(
+                path=self._store.credentials_path, tracker=tracker
             )
 
-        cache = ActivityCache(app_config.cache_dir)
-        cache.load()
+            strava_cred_map = {
+                c.id: c.credential
+                for c in app_config.connectors
+                if isinstance(c, StravaConnectorConfig)
+            }
 
-        connectors = await build_connectors(
-            app_config, provider, tracker, on_strava_token_refresh=_on_token_refresh
-        )
-        login_tasks = {
-            cid: asyncio.create_task(c.login()) for cid, c in connectors.items()
-        }
-        orchestrator = SyncOrchestrator(
-            groups=app_config.sync_groups,
-            connectors=connectors,
-            cache=cache,
-            tracker=tracker,
-            login_tasks=login_tasks,
-        )
-        try:
-            if self._gui_config.skip_wellness:
-                failures = await orchestrator.run(start, end, force=force)
-            else:
-                failures, _ = await asyncio.gather(
-                    orchestrator.run(start, end, force=force),
-                    self._run_wellness(
-                        app_config, provider, tracker, connectors, login_tasks
-                    ),
+            def _on_token_refresh(
+                connector_id: str, new_creds: object, _label: str
+            ) -> None:
+                provider.update_refresh_token(
+                    strava_cred_map[connector_id],
+                    new_creds.refresh_token,  # type: ignore[attr-defined]
                 )
+
+            cache = ActivityCache(app_config.cache_dir)
+            cache.load()
+
+            connectors = await build_connectors(
+                app_config, provider, tracker, on_strava_token_refresh=_on_token_refresh
+            )
+            login_tasks = {
+                cid: asyncio.create_task(c.login()) for cid, c in connectors.items()
+            }
+            orchestrator = SyncOrchestrator(
+                groups=app_config.sync_groups,
+                connectors=connectors,
+                cache=cache,
+                tracker=tracker,
+                login_tasks=login_tasks,
+            )
+            try:
+                if self._gui_config.skip_wellness:
+                    failures = await orchestrator.run(start, end, force=force)
+                else:
+                    failures, _ = await asyncio.gather(
+                        orchestrator.run(start, end, force=force),
+                        self._run_wellness(
+                            app_config, provider, tracker, connectors, login_tasks
+                        ),
+                    )
+            finally:
+                for t in login_tasks.values():
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*login_tasks.values(), return_exceptions=True)
+            return failures
+        except Exception as exc:
+            sync_logger.error(f"Unexpected error: {exc}", exc_info=True)
+            raise
         finally:
-            for t in login_tasks.values():
-                if not t.done():
-                    t.cancel()
-            await asyncio.gather(*login_tasks.values(), return_exceptions=True)
             sync_logger.run_end()
             sync_logger.close()
-
-        return failures
 
     async def _run_wellness(
         self,

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QDate, Qt, QThread, Signal
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QFontDatabase
 
 if TYPE_CHECKING:
     from app.core.config import AppConfig
@@ -828,7 +828,7 @@ class LogDialog(QDialog):
         layout = QVBoxLayout(self)
         text = QTextEdit()
         text.setReadOnly(True)
-        text.setFontFamily("monospace")
+        text.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
         if log_path.exists():
             text.setPlainText(log_path.read_text(encoding="utf-8", errors="replace"))
         else:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -954,21 +954,32 @@ class ConfigTab(QWidget):
         row = self._conn_list.currentRow()
         if row < 0:
             return
-        deleted_id = self._config.connectors[row].id
+        connector_id = self._config.connectors[row].id
+        using_groups = self._groups_using_connector(connector_id)
+        if using_groups:
+            groups = ", ".join(repr(g) for g in using_groups)
+            QMessageBox.warning(
+                self,
+                "Connector in use",
+                f"Connector {connector_id!r} is used in sync group(s): {groups}.\n\n"
+                "Remove it from those groups before deleting the connector.",
+            )
+            return
         reply = QMessageBox.question(
-            self, "Delete connector", f"Delete connector {deleted_id!r}?"
+            self, "Delete connector", f"Delete connector {connector_id!r}?"
         )
         if reply == QMessageBox.StandardButton.Yes:
             self._config.connectors.pop(row)
-            self._prune_connector_references(deleted_id)
             self._store.save_gui_config(self._config)
             self._refresh_connector_list()
-            self._refresh_group_list()
 
-    def _prune_connector_references(self, connector_id: str) -> None:
-        for group in self._config.sync_groups:
-            group.sources = [s for s in group.sources if s.id != connector_id]
-            group.destinations = [d for d in group.destinations if d != connector_id]
+    def _groups_using_connector(self, connector_id: str) -> list[str]:
+        return [
+            g.id
+            for g in self._config.sync_groups
+            if connector_id in {s.id for s in g.sources}
+            or connector_id in g.destinations
+        ]
 
     # ------------------------------------------------------------------
     # Sync groups

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -578,28 +578,29 @@ class ConnectorDialog(QDialog):
                 self._type.setCurrentIndex(idx)
         form.addRow("Type:", self._type)
 
-        # Credential fields (garmin + strava). These are editable combo boxes
-        # pre-populated with the accounts configured on the Credentials tab, so
-        # the user can pick a known account or still type a custom value.
+        # An account is identified by service + login; the URL belongs to that
+        # account (it comes from the credentials), so Service and Login are
+        # editable combos of the configured accounts while URL is derived from
+        # the selected account rather than chosen independently.
         self._cred_box = QGroupBox("Credentials")
         cred_form = QFormLayout(self._cred_box)
         self._cred_service = _editable_combo(
             sorted({c.service for c in self._credentials if c.service}),
             entry.credential_service if entry else "",
         )
-        self._cred_url = _editable_combo(
-            sorted({c.url for c in self._credentials if c.url}),
-            entry.credential_url if entry else "",
-        )
         self._cred_login = _editable_combo(
             sorted({c.login for c in self._credentials if c.login}),
             entry.credential_login if entry else "",
         )
-        # Selecting a known service auto-fills that account's URL and login.
+        self._cred_url = QLineEdit(entry.credential_url if entry else "")
+        self._cred_url.setReadOnly(True)
+        self._cred_url.setPlaceholderText("Filled from the selected account")
+        # Service/login changes re-derive the URL from the matching account.
         self._cred_service.currentTextChanged.connect(self._on_service_changed)
+        self._cred_login.currentTextChanged.connect(self._on_login_changed)
         cred_form.addRow("Service:", self._cred_service)
-        cred_form.addRow("URL:", self._cred_url)
         cred_form.addRow("Login (optional):", self._cred_login)
+        cred_form.addRow("URL:", self._cred_url)
 
         # Strava-only
         self._client_id_spin = QSpinBox()
@@ -640,13 +641,40 @@ class ConnectorDialog(QDialog):
         self._client_id_spin.setVisible(t == "strava")
         self._folder_box.setVisible(t == "local_folder")
 
-    def _on_service_changed(self, service: str) -> None:
-        match = next(
-            (c for c in self._credentials if c.service == service and c.service), None
+    def _account_for(self, service: str, login: str) -> CredentialEntry | None:
+        if not service:
+            return None
+        with_login = next(
+            (
+                c
+                for c in self._credentials
+                if c.service == service and (not login or c.login == login)
+            ),
+            None,
+        )
+        if with_login is not None:
+            return with_login
+        return next((c for c in self._credentials if c.service == service), None)
+
+    def _derive_url(self) -> None:
+        match = self._account_for(
+            self._cred_service.currentText().strip(),
+            self._cred_login.currentText().strip(),
         )
         if match is not None:
-            self._cred_url.setCurrentText(match.url)
+            self._cred_url.setText(match.url)
+
+    def _on_service_changed(self, service: str) -> None:
+        # Default the login to the picked service's account, then derive the URL.
+        match = self._account_for(service.strip(), "")
+        if match is not None:
+            self._cred_login.blockSignals(True)
             self._cred_login.setCurrentText(match.login)
+            self._cred_login.blockSignals(False)
+        self._derive_url()
+
+    def _on_login_changed(self, _login: str) -> None:
+        self._derive_url()
 
     def result_entry(self) -> ConnectorEntry:
         t = self._type.currentText()
@@ -654,7 +682,7 @@ class ConnectorDialog(QDialog):
             id=self._id.text().strip(),
             type=t,
             credential_service=self._cred_service.currentText().strip(),
-            credential_url=self._cred_url.currentText().strip(),
+            credential_url=self._cred_url.text().strip(),
             credential_login=self._cred_login.currentText().strip(),
             client_id=self._client_id_spin.value() if t == "strava" else 0,
             folder=self._folder.text().strip() if t == "local_folder" else "",

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -652,8 +652,12 @@ class ConnectorDialog(QDialog):
         # Local folder
         self._folder_box = QGroupBox("Local folder")
         folder_form = QFormLayout(self._folder_box)
+        folder_row = QHBoxLayout()
         self._folder = QLineEdit(entry.folder if entry else "")
-        folder_form.addRow("Path:", self._folder)
+        self._folder_browse = QPushButton("Browse...")
+        folder_row.addWidget(self._folder)
+        folder_row.addWidget(self._folder_browse)
+        folder_form.addRow("Path:", folder_row)
 
         form.addRow(self._cred_box)
         form.addRow(self._folder_box)
@@ -669,8 +673,14 @@ class ConnectorDialog(QDialog):
         self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
         self._id.textChanged.connect(self._validate)
         self._cred_combo.currentIndexChanged.connect(self._validate)
+        self._folder_browse.clicked.connect(self._browse_folder)
         self._type.currentTextChanged.connect(self._on_type_changed)
         self._on_type_changed(self._type.currentText())
+
+    def _browse_folder(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select folder")
+        if path:
+            self._folder.setText(path)
 
     def _select_credential(self, entry: ConnectorEntry | None) -> None:
         if entry is None:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -259,15 +259,6 @@ def _parse_date_or_default(value: str, default: date) -> date:
     return default
 
 
-def _editable_combo(values: list[str], current: str) -> QComboBox:
-    """A combo box pre-filled with known values that still accepts free text."""
-    combo = QComboBox()
-    combo.setEditable(True)
-    combo.addItems(values)
-    combo.setCurrentText(current)
-    return combo
-
-
 # ---------------------------------------------------------------------------
 # TaskRow - one row per sync task shown in the Sync tab
 # ---------------------------------------------------------------------------
@@ -566,8 +557,9 @@ class ConnectorDialog(QDialog):
         root = QVBoxLayout(self)
         form = QFormLayout()
 
+        # "Name" is the connector's identifier - referenced by sync groups.
         self._id = QLineEdit(entry.id if entry else "")
-        form.addRow("ID:", self._id)
+        form.addRow("Name:", self._id)
 
         self._type = QComboBox()
         self._type.addItems(list(CONNECTOR_TYPES))
@@ -577,29 +569,16 @@ class ConnectorDialog(QDialog):
                 self._type.setCurrentIndex(idx)
         form.addRow("Type:", self._type)
 
-        # An account is identified by service + login; the URL belongs to that
-        # account (it comes from the credentials), so Service and Login are
-        # editable combos of the configured accounts while URL is derived from
-        # the selected account rather than chosen independently.
+        # Credentials come from the Credentials tab - the connector just picks an
+        # account, and its service/url/login are taken from that account.
         self._cred_box = QGroupBox("Credentials")
         cred_form = QFormLayout(self._cred_box)
-        self._cred_service = _editable_combo(
-            sorted({c.service for c in self._credentials if c.service}),
-            entry.credential_service if entry else "",
-        )
-        self._cred_login = _editable_combo(
-            sorted({c.login for c in self._credentials if c.login}),
-            entry.credential_login if entry else "",
-        )
-        self._cred_url = QLineEdit(entry.credential_url if entry else "")
-        self._cred_url.setReadOnly(True)
-        self._cred_url.setPlaceholderText("Filled from the selected account")
-        # Service/login changes re-derive the URL from the matching account.
-        self._cred_service.currentTextChanged.connect(self._on_service_changed)
-        self._cred_login.currentTextChanged.connect(self._on_login_changed)
-        cred_form.addRow("Service:", self._cred_service)
-        cred_form.addRow("Login (optional):", self._cred_login)
-        cred_form.addRow("URL:", self._cred_url)
+        self._cred_combo = QComboBox()
+        for cred in self._credentials:
+            label = f"{cred.service} ({cred.login})" if cred.login else cred.service
+            self._cred_combo.addItem(label, cred)
+        self._select_credential(entry)
+        cred_form.addRow("Credentials:", self._cred_combo)
 
         # Strava-only
         self._client_id_spin = QSpinBox()
@@ -627,62 +606,45 @@ class ConnectorDialog(QDialog):
 
         self._ok_btn = btns.button(QDialogButtonBox.StandardButton.Ok)
         self._id.textChanged.connect(self._validate)
-        self._validate()
-
+        self._cred_combo.currentIndexChanged.connect(self._validate)
         self._type.currentTextChanged.connect(self._on_type_changed)
         self._on_type_changed(self._type.currentText())
 
+    def _select_credential(self, entry: ConnectorEntry | None) -> None:
+        if entry is None:
+            return
+        from app.gui.credential_provider import find_credential
+
+        match = find_credential(
+            self._credentials,
+            entry.credential_service,
+            entry.credential_url,
+            entry.credential_login or None,
+        )
+        if match is not None:
+            self._cred_combo.setCurrentIndex(self._credentials.index(match))
+
     def _validate(self) -> None:
-        self._ok_btn.setEnabled(bool(self._id.text().strip()))
+        has_name = bool(self._id.text().strip())
+        needs_cred = self._type.currentText() in ("garmin", "strava")
+        cred_ok = not needs_cred or self._cred_combo.currentData() is not None
+        self._ok_btn.setEnabled(has_name and cred_ok)
 
     def _on_type_changed(self, t: str) -> None:
         self._cred_box.setVisible(t in ("garmin", "strava"))
         self._client_id_spin.setVisible(t == "strava")
         self._folder_box.setVisible(t == "local_folder")
-
-    def _account_for(self, service: str, login: str) -> CredentialEntry | None:
-        if not service:
-            return None
-        with_login = next(
-            (
-                c
-                for c in self._credentials
-                if c.service == service and (not login or c.login == login)
-            ),
-            None,
-        )
-        if with_login is not None:
-            return with_login
-        return next((c for c in self._credentials if c.service == service), None)
-
-    def _derive_url(self) -> None:
-        match = self._account_for(
-            self._cred_service.currentText().strip(),
-            self._cred_login.currentText().strip(),
-        )
-        if match is not None:
-            self._cred_url.setText(match.url)
-
-    def _on_service_changed(self, service: str) -> None:
-        # Default the login to the picked service's account, then derive the URL.
-        match = self._account_for(service.strip(), "")
-        if match is not None:
-            self._cred_login.blockSignals(True)
-            self._cred_login.setCurrentText(match.login)
-            self._cred_login.blockSignals(False)
-        self._derive_url()
-
-    def _on_login_changed(self, _login: str) -> None:
-        self._derive_url()
+        self._validate()
 
     def result_entry(self) -> ConnectorEntry:
         t = self._type.currentText()
+        cred: CredentialEntry | None = self._cred_combo.currentData()
         return ConnectorEntry(
             id=self._id.text().strip(),
             type=t,
-            credential_service=self._cred_service.currentText().strip(),
-            credential_url=self._cred_url.text().strip(),
-            credential_login=self._cred_login.currentText().strip(),
+            credential_service=cred.service if cred else "",
+            credential_url=cred.url if cred else "",
+            credential_login=cred.login if cred else "",
             client_id=self._client_id_spin.value() if t == "strava" else 0,
             folder=self._folder.text().strip() if t == "local_folder" else "",
         )

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -669,7 +669,11 @@ class ConnectorDialog(QDialog):
 
     def result_entry(self) -> ConnectorEntry:
         t = self._type.currentText()
-        cred: CredentialEntry | None = self._cred_combo.currentData()
+        # Credentials only apply to garmin/strava - a local folder must not carry
+        # a credential, or it would spuriously "use" one and block its deletion.
+        cred: CredentialEntry | None = (
+            self._cred_combo.currentData() if t in ("garmin", "strava") else None
+        )
         return ConnectorEntry(
             id=self._id.text().strip(),
             type=t,

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -62,6 +62,7 @@ from PySide6.QtWidgets import (
 )
 
 from app.gui.config_store import (
+    CONNECTOR_TYPES,
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
@@ -570,7 +571,7 @@ class ConnectorDialog(QDialog):
         form.addRow("ID:", self._id)
 
         self._type = QComboBox()
-        self._type.addItems(["garmin", "strava", "local_folder"])
+        self._type.addItems(list(CONNECTOR_TYPES))
         if entry:
             idx = self._type.findText(entry.type)
             if idx >= 0:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -519,11 +519,32 @@ class CredentialsTab(QWidget):
         row = self._table.currentRow()
         if row < 0:
             return
-        dlg = CredentialDialog(entry=self._entries[row], parent=self)
-        if dlg.exec() == QDialog.DialogCode.Accepted:
-            self._entries[row] = dlg.result_entry()
-            self._store.save_credentials(self._entries)
-            self._refresh_table()
+        old = self._entries[row]
+        dlg = CredentialDialog(entry=old, parent=self)
+        if dlg.exec() != QDialog.DialogCode.Accepted:
+            return
+        new = dlg.result_entry()
+        identity_changed = (old.service, old.url, old.login) != (
+            new.service,
+            new.url,
+            new.login,
+        )
+        if identity_changed:
+            using = self._connectors_using_credential(old)
+            if using:
+                connectors = ", ".join(repr(c) for c in using)
+                QMessageBox.warning(
+                    self,
+                    "Credential in use",
+                    f"Credential {old.service!r} is used by connector(s): "
+                    f"{connectors}.\n\nChanging its service, URL, or login would "
+                    "detach them. Update those connectors first, or edit only the "
+                    "password / KeePass file.",
+                )
+                return
+        self._entries[row] = new
+        self._store.save_credentials(self._entries)
+        self._refresh_table()
 
     def _delete(self) -> None:
         row = self._table.currentRow()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -1056,7 +1056,9 @@ class MainWindow(QMainWindow):
     def __init__(self, store: ConfigStore) -> None:
         super().__init__()
         self.setWindowTitle("Trainings Sync")
-        self.resize(800, 600)
+        # Wide enough that the Sync tab's task rows (long connector labels plus a
+        # fixed-width progress bar and counter) fit without a horizontal scroll.
+        self.resize(1200, 760)
 
         tabs = QTabWidget()
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -786,7 +786,11 @@ class SyncGroupDialog(QDialog):
         self._validate()
 
     def _validate(self) -> None:
-        self._ok_btn.setEnabled(bool(self._id.text().strip()))
+        # A group needs a name and at least one source (the CLI rejects a group
+        # with no sources).
+        has_name = bool(self._id.text().strip())
+        has_source = self._sources_widget.count() > 0
+        self._ok_btn.setEnabled(has_name and has_source)
 
     @staticmethod
     def _make_source_item(cid: str, priority: int) -> QListWidgetItem:
@@ -812,11 +816,13 @@ class SyncGroupDialog(QDialog):
         # A connector cannot be both a source and a destination of one group.
         if cid and cid not in self._source_ids() and cid not in self._destination_ids():
             self._sources_widget.addItem(self._make_source_item(cid, pri))
+            self._validate()
 
     def _remove_source(self) -> None:
         row = self._sources_widget.currentRow()
         if row >= 0:
             self._sources_widget.takeItem(row)
+            self._validate()
 
     def _add_destination(self) -> None:
         cid = self._dst_add_combo.currentText()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -92,12 +92,19 @@ class SyncWorker(QThread):
         from app.core.connector_factory import build_connectors
         from app.core.orchestrator import SyncOrchestrator
         from app.credentials.json_file import JsonFileProvider
+        from app.tracking.sync_logger import SyncLogger
         from app.tracking.tracker import TaskTracker
 
         app_config = self._store.to_app_config(self._gui_config)
         app_config.cache_dir.mkdir(parents=True, exist_ok=True)
 
-        tracker = TaskTracker(self._renderer)
+        start = _parse_date_or_default(self._gui_config.start, date(2000, 1, 1))
+        end = _parse_date_or_default(self._gui_config.end, date.today())
+        force = self._gui_config.force
+
+        sync_logger = SyncLogger(app_config.cache_dir / "sync.log")
+        sync_logger.run_start(start=start, end=end, force=force)
+        tracker = TaskTracker(self._renderer, sync_logger=sync_logger)
         provider = JsonFileProvider(path=self._store.credentials_path, tracker=tracker)
 
         strava_cred_map = {
@@ -131,10 +138,6 @@ class SyncWorker(QThread):
             login_tasks=login_tasks,
         )
         try:
-            start = _parse_date_or_default(self._gui_config.start, date(2000, 1, 1))
-            end = _parse_date_or_default(self._gui_config.end, date.today())
-            force = self._gui_config.force
-
             if self._gui_config.skip_wellness:
                 failures = await orchestrator.run(start, end, force=force)
             else:
@@ -149,6 +152,8 @@ class SyncWorker(QThread):
                 if not t.done():
                     t.cancel()
             await asyncio.gather(*login_tasks.values(), return_exceptions=True)
+            sync_logger.run_end()
+            sync_logger.close()
 
         return failures
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -336,6 +336,13 @@ class TaskRow(QWidget):
 # ---------------------------------------------------------------------------
 
 
+# Known service endpoints offered as URL suggestions when adding a credential.
+_KNOWN_CREDENTIAL_URLS = (
+    "https://connect.garmin.com",
+    "https://www.strava.com/api/v3",
+)
+
+
 class CredentialDialog(QDialog):
     def __init__(
         self,
@@ -359,7 +366,10 @@ class CredentialDialog(QDialog):
         form.addRow("Source:", src_row)
 
         self._service = QLineEdit(entry.service if entry else "")
-        self._url = QLineEdit(entry.url if entry else "")
+        self._url = QComboBox()
+        self._url.setEditable(True)
+        self._url.addItems(_KNOWN_CREDENTIAL_URLS)
+        self._url.setCurrentText(entry.url if entry else "")
         self._login = QLineEdit(entry.login if entry else "")
         form.addRow("Service:", self._service)
         form.addRow("URL:", self._url)
@@ -428,14 +438,14 @@ class CredentialDialog(QDialog):
         if self._keepass_radio.isChecked():
             return CredentialEntry(
                 service=self._service.text().strip(),
-                url=self._url.text().strip(),
+                url=self._url.currentText().strip(),
                 login=self._login.text().strip(),
                 source="keepass",
                 keepass_path=self._keepass_path.text().strip(),
             )
         return CredentialEntry(
             service=self._service.text().strip(),
-            url=self._url.text().strip(),
+            url=self._url.currentText().strip(),
             login=self._login.text().strip(),
             password=self._password.text(),
             source="manual",

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -486,6 +486,7 @@ class CredentialsTab(QWidget):
         self._edit_btn.clicked.connect(self._edit)
         self._delete_btn.clicked.connect(self._delete)
         self._load_btn.clicked.connect(self._load_from_file)
+        self._table.itemDoubleClicked.connect(self._edit)
 
         self._refresh_table()
 
@@ -896,6 +897,7 @@ class ConfigTab(QWidget):
         self._conn_add.clicked.connect(self._add_connector)
         self._conn_edit.clicked.connect(self._edit_connector)
         self._conn_del.clicked.connect(self._delete_connector)
+        self._conn_list.itemDoubleClicked.connect(self._edit_connector)
 
         # Sync groups
         grp_box = QGroupBox("Sync Groups")
@@ -915,6 +917,7 @@ class ConfigTab(QWidget):
         self._grp_add.clicked.connect(self._add_group)
         self._grp_edit.clicked.connect(self._edit_group)
         self._grp_del.clicked.connect(self._delete_group)
+        self._grp_list.itemDoubleClicked.connect(self._edit_group)
 
         # Options
         opt_box = QGroupBox("Options")

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -960,10 +960,29 @@ class ConfigTab(QWidget):
         for c in self._config.connectors:
             self._conn_list.addItem(f"[{c.type}] {c.id}")
 
+    def _connector_name_taken(self, name: str, exclude_index: int | None) -> bool:
+        return any(
+            c.id == name
+            for i, c in enumerate(self._config.connectors)
+            if i != exclude_index
+        )
+
+    def _warn_duplicate_name(self, name: str) -> None:
+        QMessageBox.warning(
+            self,
+            "Duplicate name",
+            f"A connector named {name!r} already exists. "
+            "Connector names must be unique.",
+        )
+
     def _add_connector(self) -> None:
         dlg = ConnectorDialog(credentials=self._store.load_credentials(), parent=self)
         if dlg.exec() == QDialog.DialogCode.Accepted:
-            self._config.connectors.append(dlg.result_entry())
+            entry = dlg.result_entry()
+            if self._connector_name_taken(entry.id, exclude_index=None):
+                self._warn_duplicate_name(entry.id)
+                return
+            self._config.connectors.append(entry)
             self._store.save_gui_config(self._config)
             self._refresh_connector_list()
 
@@ -977,7 +996,11 @@ class ConfigTab(QWidget):
             parent=self,
         )
         if dlg.exec() == QDialog.DialogCode.Accepted:
-            self._config.connectors[row] = dlg.result_entry()
+            entry = dlg.result_entry()
+            if self._connector_name_taken(entry.id, exclude_index=row):
+                self._warn_duplicate_name(entry.id)
+                return
+            self._config.connectors[row] = entry
             self._store.save_gui_config(self._config)
             self._refresh_connector_list()
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -48,6 +48,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QProgressBar,
     QPushButton,
+    QRadioButton,
     QScrollArea,
     QSizePolicy,
     QSpinBox,
@@ -63,6 +64,7 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
+    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -364,6 +366,28 @@ class CredentialsTab(QWidget):
 
         layout = QVBoxLayout(self)
 
+        # Credential source selector: built-in JSON store vs external KeePass.
+        src_row = QHBoxLayout()
+        self._src_json_radio = QRadioButton("Built-in JSON store")
+        self._src_keepass_radio = QRadioButton("KeePass database")
+        src_row.addWidget(QLabel("Credential source:"))
+        src_row.addWidget(self._src_json_radio)
+        src_row.addWidget(self._src_keepass_radio)
+        src_row.addStretch()
+        layout.addLayout(src_row)
+
+        # KeePass file chooser (only relevant when KeePass is the source).
+        self._keepass_row = QWidget()
+        kp_layout = QHBoxLayout(self._keepass_row)
+        kp_layout.setContentsMargins(0, 0, 0, 0)
+        self._keepass_path = QLineEdit()
+        self._keepass_path.setPlaceholderText("Path to .kdbx file")
+        self._keepass_browse = QPushButton("Browse...")
+        kp_layout.addWidget(QLabel("KeePass file:"))
+        kp_layout.addWidget(self._keepass_path)
+        kp_layout.addWidget(self._keepass_browse)
+        layout.addWidget(self._keepass_row)
+
         self._table = QTableWidget(0, 4)
         self._table.setHorizontalHeaderLabels(["Service", "URL", "Login", "Password"])
         self._table.horizontalHeader().setSectionResizeMode(
@@ -389,7 +413,54 @@ class CredentialsTab(QWidget):
         self._delete_btn.clicked.connect(self._delete)
         self._load_btn.clicked.connect(self._load_from_file)
 
+        # Load the persisted source and reflect it in the widgets.
+        source = store.load_credential_source()
+        self._keepass_path.setText(source.keepass_path)
+        self._src_keepass_radio.setChecked(source.source == "keepass")
+        self._src_json_radio.setChecked(source.source != "keepass")
+        self._apply_source_state()
+
+        self._src_keepass_radio.toggled.connect(self._on_source_changed)
+        self._keepass_path.textChanged.connect(self._save_source)
+        self._keepass_browse.clicked.connect(self._browse_keepass)
+
         self._refresh_table()
+
+    # ------------------------------------------------------------------
+    # Credential source
+    # ------------------------------------------------------------------
+
+    def _apply_source_state(self) -> None:
+        is_keepass = self._src_keepass_radio.isChecked()
+        self._keepass_row.setVisible(is_keepass)
+        # The GUI does not edit KeePass entries; disable JSON management for it.
+        for w in (
+            self._table,
+            self._add_btn,
+            self._edit_btn,
+            self._delete_btn,
+            self._load_btn,
+        ):
+            w.setEnabled(not is_keepass)
+
+    def _on_source_changed(self) -> None:
+        self._apply_source_state()
+        self._save_source()
+
+    def _save_source(self) -> None:
+        source = "keepass" if self._src_keepass_radio.isChecked() else "json"
+        self._store.save_credential_source(
+            CredentialSource(
+                source=source, keepass_path=self._keepass_path.text().strip()
+            )
+        )
+
+    def _browse_keepass(self) -> None:
+        path_str, _ = QFileDialog.getOpenFileName(
+            self, "Select KeePass database", "", "KeePass (*.kdbx);;All files (*)"
+        )
+        if path_str:
+            self._keepass_path.setText(path_str)
 
     def _load_from_file(self) -> None:
         path_str, _ = QFileDialog.getOpenFileName(

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -563,10 +563,22 @@ class SyncGroupDialog(QDialog):
         item.setData(Qt.ItemDataRole.UserRole, (cid, priority))
         return item
 
+    def _source_ids(self) -> set[str]:
+        return {
+            self._sources_widget.item(i).data(Qt.ItemDataRole.UserRole)[0]
+            for i in range(self._sources_widget.count())
+        }
+
+    def _destination_ids(self) -> set[str]:
+        return {
+            self._destinations_widget.item(i).text()
+            for i in range(self._destinations_widget.count())
+        }
+
     def _add_source(self) -> None:
         cid = self._src_add_combo.currentText()
         pri = self._src_priority.value()
-        if cid:
+        if cid and cid not in self._source_ids():
             self._sources_widget.addItem(self._make_source_item(cid, pri))
 
     def _remove_source(self) -> None:
@@ -576,7 +588,7 @@ class SyncGroupDialog(QDialog):
 
     def _add_destination(self) -> None:
         cid = self._dst_add_combo.currentText()
-        if cid:
+        if cid and cid not in self._destination_ids():
             self._destinations_widget.addItem(cid)
 
     def _remove_destination(self) -> None:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -765,14 +765,21 @@ class ConfigTab(QWidget):
         row = self._conn_list.currentRow()
         if row < 0:
             return
-        name = self._config.connectors[row].id
+        deleted_id = self._config.connectors[row].id
         reply = QMessageBox.question(
-            self, "Delete connector", f"Delete connector {name!r}?"
+            self, "Delete connector", f"Delete connector {deleted_id!r}?"
         )
         if reply == QMessageBox.StandardButton.Yes:
             self._config.connectors.pop(row)
+            self._prune_connector_references(deleted_id)
             self._store.save_gui_config(self._config)
             self._refresh_connector_list()
+            self._refresh_group_list()
+
+    def _prune_connector_references(self, connector_id: str) -> None:
+        for group in self._config.sync_groups:
+            group.sources = [s for s in group.sources if s.id != connector_id]
+            group.destinations = [d for d in group.destinations if d != connector_id]
 
     # ------------------------------------------------------------------
     # Sync groups

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -3,13 +3,26 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import sys
 from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QDate, Qt, QThread, Signal
-from PySide6.QtGui import QAction, QFontDatabase
+from PySide6.QtCore import QDate, QPointF, QRectF, Qt, QThread, Signal
+from PySide6.QtGui import (
+    QAction,
+    QBrush,
+    QColor,
+    QFontDatabase,
+    QIcon,
+    QLinearGradient,
+    QPainter,
+    QPainterPath,
+    QPen,
+    QPixmap,
+    QPolygonF,
+)
 
 if TYPE_CHECKING:
     from app.core.config import AppConfig
@@ -1051,6 +1064,94 @@ class SyncTab(QWidget):
 
 
 # ---------------------------------------------------------------------------
+# Application icon
+# ---------------------------------------------------------------------------
+
+
+def make_app_icon(size: int = 256) -> QIcon:
+    """Render the app icon: circular sync arrows over a heartbeat line.
+
+    The two arrows convey syncing between services; the pulse line signals
+    that the data being synced is training/activity data.
+    """
+    pixmap = QPixmap(size, size)
+    pixmap.fill(Qt.GlobalColor.transparent)
+    p = QPainter(pixmap)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+    # Rounded-square background with a vertical gradient.
+    bg = QLinearGradient(0, 0, 0, size)
+    bg.setColorAt(0.0, QColor("#37a1f0"))
+    bg.setColorAt(1.0, QColor("#1667c8"))
+    radius = size * 0.22
+    p.setPen(Qt.PenStyle.NoPen)
+    p.setBrush(QBrush(bg))
+    p.drawRoundedRect(QRectF(0, 0, size, size), radius, radius)
+
+    c = size / 2.0
+    r = size * 0.27
+    pen_w = size * 0.075
+    white = QColor("#ffffff")
+
+    pen = QPen(white, pen_w)
+    pen.setCapStyle(Qt.PenCapStyle.FlatCap)
+    p.setPen(pen)
+    p.setBrush(Qt.BrushStyle.NoBrush)
+
+    # Two opposing arcs forming the circular sync symbol.
+    rect = QRectF(c - r, c - r, 2 * r, 2 * r)
+    gap = 34  # degrees left open at each arrowhead
+    span = 180 - gap
+    start_a = 118
+    start_b = start_a + 180
+    p.drawArc(rect, int(start_a * 16), int(span * 16))
+    p.drawArc(rect, int(start_b * 16), int(span * 16))
+
+    def arrowhead(angle_deg: float) -> None:
+        a = math.radians(angle_deg)
+        px = c + r * math.cos(a)
+        py = c - r * math.sin(a)
+        # Tangent for counter-clockwise travel in screen coords (y points down).
+        tx, ty = -math.sin(a), -math.cos(a)
+        nx, ny = -ty, tx
+        s = pen_w * 1.6
+        tip = QPointF(px + tx * s, py + ty * s)
+        base_l = QPointF(px + nx * s * 0.95, py + ny * s * 0.95)
+        base_r = QPointF(px - nx * s * 0.95, py - ny * s * 0.95)
+        p.setPen(Qt.PenStyle.NoPen)
+        p.setBrush(QBrush(white))
+        p.drawPolygon(QPolygonF([tip, base_l, base_r]))
+        p.setPen(pen)
+        p.setBrush(Qt.BrushStyle.NoBrush)
+
+    # Arrowheads at the leading (counter-clockwise) end of each arc.
+    arrowhead(start_a + span)
+    arrowhead(start_b + span)
+
+    # Heartbeat / pulse line across the middle to signal "training".
+    pulse = QPen(white, pen_w * 0.85)
+    pulse.setCapStyle(Qt.PenCapStyle.RoundCap)
+    pulse.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+    p.setPen(pulse)
+    path = QPainterPath()
+    points = [
+        (c - r * 0.72, c),
+        (c - r * 0.30, c),
+        (c - r * 0.12, c - r * 0.55),
+        (c + r * 0.05, c + r * 0.55),
+        (c + r * 0.28, c),
+        (c + r * 0.72, c),
+    ]
+    path.moveTo(*points[0])
+    for pt in points[1:]:
+        path.lineTo(*pt)
+    p.drawPath(path)
+
+    p.end()
+    return QIcon(pixmap)
+
+
+# ---------------------------------------------------------------------------
 # Main window
 # ---------------------------------------------------------------------------
 
@@ -1059,6 +1160,7 @@ class MainWindow(QMainWindow):
     def __init__(self, store: ConfigStore) -> None:
         super().__init__()
         self.setWindowTitle("Trainings Sync")
+        self.setWindowIcon(make_app_icon())
         # Wide enough that the Sync tab's task rows (long connector labels plus a
         # fixed-width progress bar and counter) fit without a horizontal scroll.
         self.resize(1200, 760)
@@ -1092,6 +1194,7 @@ class MainWindow(QMainWindow):
 
 def main() -> None:
     app = QApplication(sys.argv)
+    app.setWindowIcon(make_app_icon())
     store = ConfigStore()
     window = MainWindow(store)
     window.show()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -1,0 +1,985 @@
+"""PySide6 GUI for trainings-sync."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QDate, Qt, QThread, Signal
+from PySide6.QtGui import QAction
+
+if TYPE_CHECKING:
+    from app.core.config import AppConfig
+    from app.credentials.base import CredentialProvider
+    from app.tracking.tracker import TaskTracker
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QDateEdit,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMainWindow,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.gui.config_store import (
+    ConfigStore,
+    ConnectorEntry,
+    CredentialEntry,
+    GroupSourceEntry,
+    GuiConfig,
+    SyncGroupEntry,
+)
+from app.tracking.gui_renderer import GuiRenderer
+
+# ---------------------------------------------------------------------------
+# SyncWorker - runs the full sync pipeline in a background QThread
+# ---------------------------------------------------------------------------
+
+
+class SyncWorker(QThread):
+    started_ts = Signal(str)  # ISO timestamp when sync starts
+    finished_ts = Signal(str, int)  # ISO timestamp, download_failures count
+    error_occurred = Signal(str)  # error message on unexpected failure
+
+    def __init__(
+        self,
+        config_store: ConfigStore,
+        gui_config: GuiConfig,
+        renderer: GuiRenderer,
+    ) -> None:
+        super().__init__()
+        self._store = config_store
+        self._gui_config = gui_config
+        self._renderer = renderer
+
+    def run(self) -> None:
+        ts_start = datetime.now().astimezone().isoformat(timespec="seconds")
+        self.started_ts.emit(ts_start)
+        try:
+            failures = asyncio.run(self._async_sync())
+            ts_end = datetime.now().astimezone().isoformat(timespec="seconds")
+            self.finished_ts.emit(ts_end, failures)
+        except Exception as exc:
+            self.error_occurred.emit(str(exc))
+
+    async def _async_sync(self) -> int:
+        from app.core.cache import ActivityCache
+        from app.core.config import StravaConnectorConfig
+        from app.core.connector_factory import build_connectors
+        from app.core.orchestrator import SyncOrchestrator
+        from app.credentials.json_file import JsonFileProvider
+        from app.tracking.tracker import TaskTracker
+
+        app_config = self._store.to_app_config(self._gui_config)
+        app_config.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        tracker = TaskTracker(self._renderer)
+        provider = JsonFileProvider(path=self._store.credentials_path, tracker=tracker)
+
+        strava_cred_map = {
+            c.id: c.credential
+            for c in app_config.connectors
+            if isinstance(c, StravaConnectorConfig)
+        }
+
+        def _on_token_refresh(
+            connector_id: str, new_creds: object, _label: str
+        ) -> None:
+            provider.update_refresh_token(
+                strava_cred_map[connector_id],
+                new_creds.refresh_token,  # type: ignore[attr-defined]
+            )
+
+        cache = ActivityCache(app_config.cache_dir)
+        cache.load()
+
+        connectors = await build_connectors(
+            app_config, provider, tracker, on_strava_token_refresh=_on_token_refresh
+        )
+        login_tasks = {
+            cid: asyncio.create_task(c.login()) for cid, c in connectors.items()
+        }
+        orchestrator = SyncOrchestrator(
+            groups=app_config.sync_groups,
+            connectors=connectors,
+            cache=cache,
+            tracker=tracker,
+            login_tasks=login_tasks,
+        )
+        try:
+            start = _parse_date_or_default(self._gui_config.start, date(2000, 1, 1))
+            end = _parse_date_or_default(self._gui_config.end, date.today())
+            force = self._gui_config.force
+
+            if self._gui_config.skip_wellness:
+                failures = await orchestrator.run(start, end, force=force)
+            else:
+                failures, _ = await asyncio.gather(
+                    orchestrator.run(start, end, force=force),
+                    self._run_wellness(
+                        app_config, provider, tracker, connectors, login_tasks
+                    ),
+                )
+        finally:
+            for t in login_tasks.values():
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*login_tasks.values(), return_exceptions=True)
+
+        return failures
+
+    async def _run_wellness(
+        self,
+        app_config: AppConfig,
+        provider: CredentialProvider,
+        tracker: TaskTracker,
+        connectors: dict,
+        login_tasks: dict,
+    ) -> None:
+        try:
+            from app.connectors.local_folder_wellness import (
+                LocalFolderWellnessConnector,
+            )
+            from app.core.connector_factory import build_wellness_connectors
+            from app.core.wellness_cache import WellnessCache
+            from app.core.wellness_orchestrator import WellnessOrchestrator
+
+            start = _parse_date_or_default(self._gui_config.start, date(2000, 1, 1))
+            end = _parse_date_or_default(self._gui_config.end, date.today())
+
+            wellness_cache = WellnessCache(app_config.cache_dir)
+            wellness_connectors = await build_wellness_connectors(
+                app_config, provider, tracker, connectors
+            )
+            for wc in wellness_connectors.values():
+                if isinstance(wc, LocalFolderWellnessConnector):
+                    await wc.login()
+            wellness_orch = WellnessOrchestrator(
+                wellness_connectors,
+                wellness_cache,
+                tracker,
+                login_tasks=login_tasks,
+            )
+            await wellness_orch.run(start, end, force=self._gui_config.force)
+        except Exception:  # noqa: S110
+            pass  # wellness failures are non-fatal, mirroring CLI behaviour
+
+
+def _parse_date_or_default(value: str, default: date) -> date:
+    if value:
+        return date.fromisoformat(value)
+    return default
+
+
+# ---------------------------------------------------------------------------
+# TaskRow - one row per sync task shown in the Sync tab
+# ---------------------------------------------------------------------------
+
+
+class TaskRow(QWidget):
+    def __init__(
+        self, name: str, total: int | None, parent: QWidget | None = None
+    ) -> None:
+        super().__init__(parent)
+        self._name = name
+        self._total = total
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 2, 4, 2)
+
+        self._status = QLabel("[~]")  # [~]
+        self._status.setFixedWidth(24)
+        layout.addWidget(self._status)
+
+        self._label = QLabel(name)
+        self._label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        layout.addWidget(self._label)
+
+        self._bar = QProgressBar()
+        self._bar.setFixedWidth(220)
+        if total is not None:
+            self._bar.setRange(0, total)
+            self._bar.setValue(0)
+        else:
+            self._bar.setRange(0, 0)  # indeterminate spinner
+        layout.addWidget(self._bar)
+
+        self._count = QLabel("")
+        self._count.setFixedWidth(64)
+        self._count.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        layout.addWidget(self._count)
+
+    def update_progress(self, progress: int) -> None:
+        if self._total is not None:
+            self._bar.setRange(0, self._total)
+        self._bar.setValue(progress)
+        self._count.setText(
+            f"{progress}/{self._total}" if self._total is not None else str(progress)
+        )
+
+    def update_total(self, total: int) -> None:
+        self._total = total
+        self._bar.setRange(0, total)
+
+    def mark_done(self, warnings: list[str]) -> None:
+        cap = max(1, self._total or 1)
+        self._bar.setRange(0, cap)
+        self._bar.setValue(cap)
+        if warnings:
+            self._status.setText("[!]")  # [!]
+            self._label.setText(f"{self._name} ({len(warnings)} warning(s))")
+        else:
+            self._status.setText("[OK]")  # [OK]
+
+    def mark_failed(self, error: str) -> None:
+        self._status.setText("[X]")  # [X]
+        self._label.setText(f"{self._name}: {error}")
+
+
+# ---------------------------------------------------------------------------
+# Credentials tab
+# ---------------------------------------------------------------------------
+
+
+class CredentialDialog(QDialog):
+    def __init__(
+        self,
+        entry: CredentialEntry | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add Credential" if entry is None else "Edit Credential")
+        self.setMinimumWidth(420)
+
+        form = QFormLayout(self)
+
+        self._service = QLineEdit(entry.service if entry else "")
+        self._url = QLineEdit(entry.url if entry else "")
+        self._login = QLineEdit(entry.login if entry else "")
+        self._password = QLineEdit(entry.password if entry else "")
+        self._password.setEchoMode(QLineEdit.EchoMode.Password)
+
+        form.addRow("Service:", self._service)
+        form.addRow("URL:", self._url)
+        form.addRow("Login:", self._login)
+        form.addRow("Password / Token:", self._password)
+
+        hint = QLabel("For Strava: login = client_secret, password = refresh_token")
+        hint.setWordWrap(True)
+        form.addRow(hint)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        form.addRow(btns)
+
+    def result_entry(self) -> CredentialEntry:
+        return CredentialEntry(
+            service=self._service.text().strip(),
+            url=self._url.text().strip(),
+            login=self._login.text().strip(),
+            password=self._password.text(),
+        )
+
+
+class CredentialsTab(QWidget):
+    def __init__(self, store: ConfigStore, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._store = store
+        self._entries: list[CredentialEntry] = store.load_credentials()
+
+        layout = QVBoxLayout(self)
+
+        self._table = QTableWidget(0, 4)
+        self._table.setHorizontalHeaderLabels(["Service", "URL", "Login", "Password"])
+        self._table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch
+        )
+        self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self._table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        layout.addWidget(self._table)
+
+        btn_row = QHBoxLayout()
+        self._add_btn = QPushButton("Add")
+        self._edit_btn = QPushButton("Edit")
+        self._delete_btn = QPushButton("Delete")
+        for btn in (self._add_btn, self._edit_btn, self._delete_btn):
+            btn_row.addWidget(btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+
+        self._add_btn.clicked.connect(self._add)
+        self._edit_btn.clicked.connect(self._edit)
+        self._delete_btn.clicked.connect(self._delete)
+
+        self._refresh_table()
+
+    def _refresh_table(self) -> None:
+        self._table.setRowCount(0)
+        for entry in self._entries:
+            row = self._table.rowCount()
+            self._table.insertRow(row)
+            self._table.setItem(row, 0, QTableWidgetItem(entry.service))
+            self._table.setItem(row, 1, QTableWidgetItem(entry.url))
+            self._table.setItem(row, 2, QTableWidgetItem(entry.login))
+            self._table.setItem(row, 3, QTableWidgetItem("*" * 8))
+
+    def _add(self) -> None:
+        dlg = CredentialDialog(parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._entries.append(dlg.result_entry())
+            self._store.save_credentials(self._entries)
+            self._refresh_table()
+
+    def _edit(self) -> None:
+        row = self._table.currentRow()
+        if row < 0:
+            return
+        dlg = CredentialDialog(entry=self._entries[row], parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._entries[row] = dlg.result_entry()
+            self._store.save_credentials(self._entries)
+            self._refresh_table()
+
+    def _delete(self) -> None:
+        row = self._table.currentRow()
+        if row < 0:
+            return
+        entry = self._entries[row]
+        reply = QMessageBox.question(
+            self,
+            "Delete credential",
+            f"Delete credential for {entry.service!r}?",
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self._entries.pop(row)
+            self._store.save_credentials(self._entries)
+            self._refresh_table()
+
+
+# ---------------------------------------------------------------------------
+# Configuration tab
+# ---------------------------------------------------------------------------
+
+
+class ConnectorDialog(QDialog):
+    def __init__(
+        self,
+        entry: ConnectorEntry | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add Connector" if entry is None else "Edit Connector")
+        self.setMinimumWidth(440)
+
+        root = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self._id = QLineEdit(entry.id if entry else "")
+        form.addRow("ID:", self._id)
+
+        self._type = QComboBox()
+        self._type.addItems(["garmin", "strava", "local_folder"])
+        if entry:
+            idx = self._type.findText(entry.type)
+            if idx >= 0:
+                self._type.setCurrentIndex(idx)
+        form.addRow("Type:", self._type)
+
+        # Credential fields (garmin + strava)
+        self._cred_box = QGroupBox("Credentials")
+        cred_form = QFormLayout(self._cred_box)
+        self._cred_service = QLineEdit(entry.credential_service if entry else "")
+        self._cred_url = QLineEdit(entry.credential_url if entry else "")
+        self._cred_login = QLineEdit(entry.credential_login if entry else "")
+        cred_form.addRow("Service:", self._cred_service)
+        cred_form.addRow("URL:", self._cred_url)
+        cred_form.addRow("Login (optional):", self._cred_login)
+
+        # Strava-only
+        self._client_id_spin = QSpinBox()
+        self._client_id_spin.setRange(0, 999_999_999)
+        if entry:
+            self._client_id_spin.setValue(entry.client_id)
+        cred_form.addRow("Client ID (Strava):", self._client_id_spin)
+
+        # Local folder
+        self._folder_box = QGroupBox("Local folder")
+        folder_form = QFormLayout(self._folder_box)
+        self._folder = QLineEdit(entry.folder if entry else "")
+        folder_form.addRow("Path:", self._folder)
+
+        form.addRow(self._cred_box)
+        form.addRow(self._folder_box)
+        root.addLayout(form)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        root.addWidget(btns)
+
+        self._type.currentTextChanged.connect(self._on_type_changed)
+        self._on_type_changed(self._type.currentText())
+
+    def _on_type_changed(self, t: str) -> None:
+        self._cred_box.setVisible(t in ("garmin", "strava"))
+        self._client_id_spin.setVisible(t == "strava")
+        self._folder_box.setVisible(t == "local_folder")
+
+    def result_entry(self) -> ConnectorEntry:
+        t = self._type.currentText()
+        return ConnectorEntry(
+            id=self._id.text().strip(),
+            type=t,
+            credential_service=self._cred_service.text().strip(),
+            credential_url=self._cred_url.text().strip(),
+            credential_login=self._cred_login.text().strip(),
+            client_id=self._client_id_spin.value() if t == "strava" else 0,
+            folder=self._folder.text().strip() if t == "local_folder" else "",
+        )
+
+
+class SyncGroupDialog(QDialog):
+    def __init__(
+        self,
+        connector_ids: list[str],
+        entry: SyncGroupEntry | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add Sync Group" if entry is None else "Edit Sync Group")
+        self.setMinimumWidth(480)
+        self._connector_ids = connector_ids
+
+        root = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self._id = QLineEdit(entry.id if entry else "")
+        form.addRow("Group ID:", self._id)
+        root.addLayout(form)
+
+        # Sources
+        src_box = QGroupBox("Sources (connector id : priority)")
+        src_layout = QVBoxLayout(src_box)
+        self._sources_widget = QListWidget()
+        if entry:
+            for s in entry.sources:
+                self._sources_widget.addItem(f"{s.id}:{s.priority}")
+        src_layout.addWidget(self._sources_widget)
+        src_btn_row = QHBoxLayout()
+        self._src_add_combo = QComboBox()
+        self._src_add_combo.addItems(connector_ids)
+        self._src_priority = QSpinBox()
+        self._src_priority.setRange(1, 99)
+        self._src_priority.setValue(1)
+        self._src_add_btn = QPushButton("Add source")
+        self._src_del_btn = QPushButton("Remove")
+        self._src_add_btn.clicked.connect(self._add_source)
+        self._src_del_btn.clicked.connect(self._remove_source)
+        src_btn_row.addWidget(self._src_add_combo)
+        src_btn_row.addWidget(QLabel("priority:"))
+        src_btn_row.addWidget(self._src_priority)
+        src_btn_row.addWidget(self._src_add_btn)
+        src_btn_row.addWidget(self._src_del_btn)
+        src_layout.addLayout(src_btn_row)
+        root.addWidget(src_box)
+
+        # Destinations
+        dst_box = QGroupBox("Destinations (connector ids)")
+        dst_layout = QVBoxLayout(dst_box)
+        self._destinations_widget = QListWidget()
+        if entry:
+            for d in entry.destinations:
+                self._destinations_widget.addItem(d)
+        dst_layout.addWidget(self._destinations_widget)
+        dst_btn_row = QHBoxLayout()
+        self._dst_add_combo = QComboBox()
+        self._dst_add_combo.addItems(connector_ids)
+        self._dst_add_btn = QPushButton("Add destination")
+        self._dst_del_btn = QPushButton("Remove")
+        self._dst_add_btn.clicked.connect(self._add_destination)
+        self._dst_del_btn.clicked.connect(self._remove_destination)
+        dst_btn_row.addWidget(self._dst_add_combo)
+        dst_btn_row.addWidget(self._dst_add_btn)
+        dst_btn_row.addWidget(self._dst_del_btn)
+        dst_layout.addLayout(dst_btn_row)
+        root.addWidget(dst_box)
+
+        btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        root.addWidget(btns)
+
+    def _add_source(self) -> None:
+        cid = self._src_add_combo.currentText()
+        pri = self._src_priority.value()
+        if cid:
+            self._sources_widget.addItem(f"{cid}:{pri}")
+
+    def _remove_source(self) -> None:
+        row = self._sources_widget.currentRow()
+        if row >= 0:
+            self._sources_widget.takeItem(row)
+
+    def _add_destination(self) -> None:
+        cid = self._dst_add_combo.currentText()
+        if cid:
+            self._destinations_widget.addItem(cid)
+
+    def _remove_destination(self) -> None:
+        row = self._destinations_widget.currentRow()
+        if row >= 0:
+            self._destinations_widget.takeItem(row)
+
+    def result_entry(self) -> SyncGroupEntry:
+        sources = []
+        for i in range(self._sources_widget.count()):
+            text = self._sources_widget.item(i).text()
+            cid, _, pri_str = text.partition(":")
+            sources.append(
+                GroupSourceEntry(id=cid.strip(), priority=int(pri_str or "1"))
+            )
+        destinations = [
+            self._destinations_widget.item(i).text()
+            for i in range(self._destinations_widget.count())
+        ]
+        return SyncGroupEntry(
+            id=self._id.text().strip(),
+            sources=sources,
+            destinations=destinations,
+        )
+
+
+class ConfigTab(QWidget):
+    def __init__(self, store: ConfigStore, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._store = store
+        self._config: GuiConfig = store.load_gui_config()
+
+        root = QVBoxLayout(self)
+
+        # Connectors
+        conn_box = QGroupBox("Connectors")
+        conn_layout = QVBoxLayout(conn_box)
+        self._conn_list = QListWidget()
+        conn_layout.addWidget(self._conn_list)
+        conn_btn_row = QHBoxLayout()
+        self._conn_add = QPushButton("Add")
+        self._conn_edit = QPushButton("Edit")
+        self._conn_del = QPushButton("Delete")
+        for b in (self._conn_add, self._conn_edit, self._conn_del):
+            conn_btn_row.addWidget(b)
+        conn_btn_row.addStretch()
+        conn_layout.addLayout(conn_btn_row)
+        root.addWidget(conn_box)
+
+        self._conn_add.clicked.connect(self._add_connector)
+        self._conn_edit.clicked.connect(self._edit_connector)
+        self._conn_del.clicked.connect(self._delete_connector)
+
+        # Sync groups
+        grp_box = QGroupBox("Sync Groups")
+        grp_layout = QVBoxLayout(grp_box)
+        self._grp_list = QListWidget()
+        grp_layout.addWidget(self._grp_list)
+        grp_btn_row = QHBoxLayout()
+        self._grp_add = QPushButton("Add")
+        self._grp_edit = QPushButton("Edit")
+        self._grp_del = QPushButton("Delete")
+        for b in (self._grp_add, self._grp_edit, self._grp_del):
+            grp_btn_row.addWidget(b)
+        grp_btn_row.addStretch()
+        grp_layout.addLayout(grp_btn_row)
+        root.addWidget(grp_box)
+
+        self._grp_add.clicked.connect(self._add_group)
+        self._grp_edit.clicked.connect(self._edit_group)
+        self._grp_del.clicked.connect(self._delete_group)
+
+        # Options
+        opt_box = QGroupBox("Options")
+        opt_layout = QFormLayout(opt_box)
+
+        date_row_start = QHBoxLayout()
+        self._use_start = QCheckBox("Use custom start date")
+        self._start_date = QDateEdit()
+        self._start_date.setCalendarPopup(True)
+        self._start_date.setDisplayFormat("yyyy-MM-dd")
+        if self._config.start:
+            d = date.fromisoformat(self._config.start)
+            self._start_date.setDate(QDate(d.year, d.month, d.day))
+            self._use_start.setChecked(True)
+        else:
+            self._start_date.setDate(QDate.currentDate())
+        self._start_date.setEnabled(self._use_start.isChecked())
+        self._use_start.toggled.connect(self._start_date.setEnabled)
+        date_row_start.addWidget(self._use_start)
+        date_row_start.addWidget(self._start_date)
+        opt_layout.addRow("Start:", date_row_start)
+
+        date_row_end = QHBoxLayout()
+        self._use_end = QCheckBox("Use custom end date")
+        self._end_date = QDateEdit()
+        self._end_date.setCalendarPopup(True)
+        self._end_date.setDisplayFormat("yyyy-MM-dd")
+        if self._config.end:
+            d2 = date.fromisoformat(self._config.end)
+            self._end_date.setDate(QDate(d2.year, d2.month, d2.day))
+            self._use_end.setChecked(True)
+        else:
+            self._end_date.setDate(QDate.currentDate())
+        self._end_date.setEnabled(self._use_end.isChecked())
+        self._use_end.toggled.connect(self._end_date.setEnabled)
+        date_row_end.addWidget(self._use_end)
+        date_row_end.addWidget(self._end_date)
+        opt_layout.addRow("End:", date_row_end)
+
+        self._force_cb = QCheckBox("Force re-download (ignore cache)")
+        self._force_cb.setChecked(self._config.force)
+        opt_layout.addRow(self._force_cb)
+
+        self._skip_wellness_cb = QCheckBox("Skip wellness sync")
+        self._skip_wellness_cb.setChecked(self._config.skip_wellness)
+        opt_layout.addRow(self._skip_wellness_cb)
+
+        save_btn = QPushButton("Save configuration")
+        save_btn.clicked.connect(self._save)
+        opt_layout.addRow(save_btn)
+
+        root.addWidget(opt_box)
+        root.addStretch()
+
+        self._refresh_connector_list()
+        self._refresh_group_list()
+
+    # ------------------------------------------------------------------
+    # Connectors
+    # ------------------------------------------------------------------
+
+    def _refresh_connector_list(self) -> None:
+        self._conn_list.clear()
+        for c in self._config.connectors:
+            self._conn_list.addItem(f"[{c.type}] {c.id}")
+
+    def _add_connector(self) -> None:
+        dlg = ConnectorDialog(parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._config.connectors.append(dlg.result_entry())
+            self._store.save_gui_config(self._config)
+            self._refresh_connector_list()
+
+    def _edit_connector(self) -> None:
+        row = self._conn_list.currentRow()
+        if row < 0:
+            return
+        dlg = ConnectorDialog(entry=self._config.connectors[row], parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._config.connectors[row] = dlg.result_entry()
+            self._store.save_gui_config(self._config)
+            self._refresh_connector_list()
+
+    def _delete_connector(self) -> None:
+        row = self._conn_list.currentRow()
+        if row < 0:
+            return
+        name = self._config.connectors[row].id
+        reply = QMessageBox.question(
+            self, "Delete connector", f"Delete connector {name!r}?"
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self._config.connectors.pop(row)
+            self._store.save_gui_config(self._config)
+            self._refresh_connector_list()
+
+    # ------------------------------------------------------------------
+    # Sync groups
+    # ------------------------------------------------------------------
+
+    def _connector_ids(self) -> list[str]:
+        return [c.id for c in self._config.connectors]
+
+    def _refresh_group_list(self) -> None:
+        self._grp_list.clear()
+        for g in self._config.sync_groups:
+            src_str = ", ".join(f"{s.id}(p{s.priority})" for s in g.sources)
+            dst_str = ", ".join(g.destinations)
+            self._grp_list.addItem(f"{g.id}  [{src_str}] -> [{dst_str}]")
+
+    def _add_group(self) -> None:
+        dlg = SyncGroupDialog(connector_ids=self._connector_ids(), parent=self)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._config.sync_groups.append(dlg.result_entry())
+            self._store.save_gui_config(self._config)
+            self._refresh_group_list()
+
+    def _edit_group(self) -> None:
+        row = self._grp_list.currentRow()
+        if row < 0:
+            return
+        dlg = SyncGroupDialog(
+            connector_ids=self._connector_ids(),
+            entry=self._config.sync_groups[row],
+            parent=self,
+        )
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._config.sync_groups[row] = dlg.result_entry()
+            self._store.save_gui_config(self._config)
+            self._refresh_group_list()
+
+    def _delete_group(self) -> None:
+        row = self._grp_list.currentRow()
+        if row < 0:
+            return
+        name = self._config.sync_groups[row].id
+        reply = QMessageBox.question(
+            self, "Delete group", f"Delete sync group {name!r}?"
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self._config.sync_groups.pop(row)
+            self._store.save_gui_config(self._config)
+            self._refresh_group_list()
+
+    # ------------------------------------------------------------------
+    # Save options
+    # ------------------------------------------------------------------
+
+    def _save(self) -> None:
+        self._config.force = self._force_cb.isChecked()
+        self._config.skip_wellness = self._skip_wellness_cb.isChecked()
+        self._config.start = (
+            self._start_date.date().toString("yyyy-MM-dd")
+            if self._use_start.isChecked()
+            else ""
+        )
+        self._config.end = (
+            self._end_date.date().toString("yyyy-MM-dd")
+            if self._use_end.isChecked()
+            else ""
+        )
+        self._store.save_gui_config(self._config)
+
+    def current_config(self) -> GuiConfig:
+        """Return live config with current option widget values."""
+        self._save()
+        return self._config
+
+
+# ---------------------------------------------------------------------------
+# Sync tab
+# ---------------------------------------------------------------------------
+
+
+class LogDialog(QDialog):
+    def __init__(self, log_path: Path, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Full sync log")
+        self.resize(800, 600)
+
+        layout = QVBoxLayout(self)
+        text = QTextEdit()
+        text.setReadOnly(True)
+        text.setFontFamily("monospace")
+        if log_path.exists():
+            text.setPlainText(log_path.read_text(encoding="utf-8", errors="replace"))
+        else:
+            text.setPlainText("(log file not found)")
+        layout.addWidget(text)
+
+        btns = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        btns.rejected.connect(self.reject)
+        layout.addWidget(btns)
+
+
+class SyncTab(QWidget):
+    def __init__(
+        self,
+        store: ConfigStore,
+        config_tab: ConfigTab,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._store = store
+        self._config_tab = config_tab
+        self._worker: SyncWorker | None = None
+        self._task_rows: dict[str, TaskRow] = {}
+
+        root = QVBoxLayout(self)
+
+        # Toolbar
+        toolbar = QHBoxLayout()
+        self._run_btn = QPushButton(">  Run Sync")
+        self._run_btn.setFixedHeight(36)
+        self._log_btn = QPushButton("\U0001f4cb  Show full log")
+        toolbar.addWidget(self._run_btn)
+        toolbar.addWidget(self._log_btn)
+        toolbar.addStretch()
+        root.addLayout(toolbar)
+
+        self._status = QLabel("Ready")
+        root.addWidget(self._status)
+
+        # Scrollable task list
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        self._task_container = QWidget()
+        self._task_layout = QVBoxLayout(self._task_container)
+        self._task_layout.setSpacing(2)
+        self._task_layout.addStretch()
+        scroll.setWidget(self._task_container)
+        root.addWidget(scroll)
+
+        self._run_btn.clicked.connect(self._run_sync)
+        self._log_btn.clicked.connect(self._show_log)
+
+    def _run_sync(self) -> None:
+        gui_config = self._config_tab.current_config()
+
+        # Clear previous task rows
+        while self._task_layout.count() > 1:  # keep the trailing stretch
+            item = self._task_layout.takeAt(0)
+            if item is not None:
+                widget = item.widget()
+                if widget is not None:
+                    widget.deleteLater()
+        self._task_rows.clear()
+
+        renderer = GuiRenderer()
+        sigs = renderer.signals
+        sigs.task_added.connect(self._on_task_added)
+        sigs.progress_updated.connect(self._on_progress)
+        sigs.task_done.connect(self._on_task_done)
+        sigs.task_failed.connect(self._on_task_failed)
+        sigs.total_updated.connect(self._on_total_updated)
+
+        self._worker = SyncWorker(self._store, gui_config, renderer)
+        self._worker.started_ts.connect(self._on_started)
+        self._worker.finished_ts.connect(self._on_finished)
+        self._worker.error_occurred.connect(self._on_error)
+
+        self._run_btn.setEnabled(False)
+        self._worker.start()
+
+    def _on_started(self, ts: str) -> None:
+        self._status.setText(f"Sync started: {ts}")
+
+    def _on_finished(self, ts: str, failures: int) -> None:
+        self._run_btn.setEnabled(True)
+        msg = f"Sync finished: {ts}"
+        if failures:
+            noun = "activity" if failures == 1 else "activities"
+            msg += f"  [!] {failures} {noun} failed to download"
+        self._status.setText(msg)
+
+    def _on_error(self, error: str) -> None:
+        self._run_btn.setEnabled(True)
+        self._status.setText(f"[X] Error: {error}")
+        QMessageBox.critical(self, "Sync error", error)
+
+    def _on_task_added(self, name: str, total: object) -> None:
+        row = TaskRow(
+            name, total if isinstance(total, int) else None, self._task_container
+        )
+        self._task_rows[name] = row
+        # Insert before the trailing stretch
+        self._task_layout.insertWidget(self._task_layout.count() - 1, row)
+
+    def _on_progress(self, name: str, progress: int) -> None:
+        if row := self._task_rows.get(name):
+            row.update_progress(progress)
+
+    def _on_task_done(self, name: str, warnings: list) -> None:
+        if row := self._task_rows.get(name):
+            row.mark_done(warnings)
+
+    def _on_task_failed(self, name: str, error: str) -> None:
+        if row := self._task_rows.get(name):
+            row.mark_failed(error)
+
+    def _on_total_updated(self, name: str, total: int) -> None:
+        if row := self._task_rows.get(name):
+            row.update_total(total)
+
+    def _show_log(self) -> None:
+        log_path = self._store.cache_dir / "sync.log"
+        dlg = LogDialog(log_path, parent=self)
+        dlg.exec()
+
+
+# ---------------------------------------------------------------------------
+# Main window
+# ---------------------------------------------------------------------------
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, store: ConfigStore) -> None:
+        super().__init__()
+        self.setWindowTitle("Trainings Sync")
+        self.resize(800, 600)
+
+        tabs = QTabWidget()
+
+        self._creds_tab = CredentialsTab(store)
+        self._config_tab = ConfigTab(store)
+        self._sync_tab = SyncTab(store, self._config_tab)
+
+        tabs.addTab(self._creds_tab, "Credentials")
+        tabs.addTab(self._config_tab, "Configuration")
+        tabs.addTab(self._sync_tab, "Sync")
+
+        self.setCentralWidget(tabs)
+
+        quit_action = QAction("Quit", self)
+        quit_action.setShortcut("Ctrl+Q")
+        quit_action.triggered.connect(self.close)
+        file_menu = self.menuBar().addMenu("File")
+        file_menu.addAction(quit_action)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    store = ConfigStore()
+    window = MainWindow(store)
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -1012,9 +1012,12 @@ class MainWindow(QMainWindow):
         self._config_tab = ConfigTab(store)
         self._sync_tab = SyncTab(store, self._config_tab)
 
-        tabs.addTab(self._creds_tab, "Credentials")
-        tabs.addTab(self._config_tab, "Configuration")
+        # Ordered by how often each is used after initial setup: Sync (every
+        # run) first, Configuration (occasional) next, Credentials (rarely
+        # changed) last.
         tabs.addTab(self._sync_tab, "Sync")
+        tabs.addTab(self._config_tab, "Configuration")
+        tabs.addTab(self._creds_tab, "Credentials")
 
         self.setCentralWidget(tabs)
 

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import (
     QDateEdit,
     QDialog,
     QDialogButtonBox,
+    QFileDialog,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -351,15 +352,35 @@ class CredentialsTab(QWidget):
         self._add_btn = QPushButton("Add")
         self._edit_btn = QPushButton("Edit")
         self._delete_btn = QPushButton("Delete")
+        self._load_btn = QPushButton("Load from file...")
         for btn in (self._add_btn, self._edit_btn, self._delete_btn):
             btn_row.addWidget(btn)
         btn_row.addStretch()
+        btn_row.addWidget(self._load_btn)
         layout.addLayout(btn_row)
 
         self._add_btn.clicked.connect(self._add)
         self._edit_btn.clicked.connect(self._edit)
         self._delete_btn.clicked.connect(self._delete)
+        self._load_btn.clicked.connect(self._load_from_file)
 
+        self._refresh_table()
+
+    def _load_from_file(self) -> None:
+        path_str, _ = QFileDialog.getOpenFileName(
+            self, "Load credentials", "", "JSON files (*.json);;All files (*)"
+        )
+        if not path_str:
+            return
+        try:
+            entries = self._store.load_credentials_from(Path(path_str))
+        except (OSError, ValueError, KeyError) as exc:
+            QMessageBox.critical(
+                self, "Load failed", f"Could not load credentials:\n{exc}"
+            )
+            return
+        self._entries = entries
+        self._store.save_credentials(self._entries)
         self._refresh_table()
 
     def _refresh_table(self) -> None:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -66,7 +66,6 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
-    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -443,30 +442,10 @@ class CredentialsTab(QWidget):
 
         layout = QVBoxLayout(self)
 
-        # Credential source selector: built-in JSON store vs external KeePass.
-        src_row = QHBoxLayout()
-        self._src_json_radio = QRadioButton("Built-in JSON store")
-        self._src_keepass_radio = QRadioButton("KeePass database")
-        src_row.addWidget(QLabel("Credential source:"))
-        src_row.addWidget(self._src_json_radio)
-        src_row.addWidget(self._src_keepass_radio)
-        src_row.addStretch()
-        layout.addLayout(src_row)
-
-        # KeePass file chooser (only relevant when KeePass is the source).
-        self._keepass_row = QWidget()
-        kp_layout = QHBoxLayout(self._keepass_row)
-        kp_layout.setContentsMargins(0, 0, 0, 0)
-        self._keepass_path = QLineEdit()
-        self._keepass_path.setPlaceholderText("Path to .kdbx file")
-        self._keepass_browse = QPushButton("Browse...")
-        kp_layout.addWidget(QLabel("KeePass file:"))
-        kp_layout.addWidget(self._keepass_path)
-        kp_layout.addWidget(self._keepass_browse)
-        layout.addWidget(self._keepass_row)
-
-        self._table = QTableWidget(0, 4)
-        self._table.setHorizontalHeaderLabels(["Service", "URL", "Login", "Password"])
+        self._table = QTableWidget(0, 5)
+        self._table.setHorizontalHeaderLabels(
+            ["Service", "URL", "Login", "Source", "Secret / KeePass file"]
+        )
         self._table.horizontalHeader().setSectionResizeMode(
             QHeaderView.ResizeMode.Stretch
         )
@@ -490,54 +469,7 @@ class CredentialsTab(QWidget):
         self._delete_btn.clicked.connect(self._delete)
         self._load_btn.clicked.connect(self._load_from_file)
 
-        # Load the persisted source and reflect it in the widgets.
-        source = store.load_credential_source()
-        self._keepass_path.setText(source.keepass_path)
-        self._src_keepass_radio.setChecked(source.source == "keepass")
-        self._src_json_radio.setChecked(source.source != "keepass")
-        self._apply_source_state()
-
-        self._src_keepass_radio.toggled.connect(self._on_source_changed)
-        self._keepass_path.textChanged.connect(self._save_source)
-        self._keepass_browse.clicked.connect(self._browse_keepass)
-
         self._refresh_table()
-
-    # ------------------------------------------------------------------
-    # Credential source
-    # ------------------------------------------------------------------
-
-    def _apply_source_state(self) -> None:
-        is_keepass = self._src_keepass_radio.isChecked()
-        self._keepass_row.setVisible(is_keepass)
-        # The GUI does not edit KeePass entries; disable JSON management for it.
-        for w in (
-            self._table,
-            self._add_btn,
-            self._edit_btn,
-            self._delete_btn,
-            self._load_btn,
-        ):
-            w.setEnabled(not is_keepass)
-
-    def _on_source_changed(self) -> None:
-        self._apply_source_state()
-        self._save_source()
-
-    def _save_source(self) -> None:
-        source = "keepass" if self._src_keepass_radio.isChecked() else "json"
-        self._store.save_credential_source(
-            CredentialSource(
-                source=source, keepass_path=self._keepass_path.text().strip()
-            )
-        )
-
-    def _browse_keepass(self) -> None:
-        path_str, _ = QFileDialog.getOpenFileName(
-            self, "Select KeePass database", "", "KeePass (*.kdbx);;All files (*)"
-        )
-        if path_str:
-            self._keepass_path.setText(path_str)
 
     def _load_from_file(self) -> None:
         path_str, _ = QFileDialog.getOpenFileName(
@@ -564,7 +496,9 @@ class CredentialsTab(QWidget):
             self._table.setItem(row, 0, QTableWidgetItem(entry.service))
             self._table.setItem(row, 1, QTableWidgetItem(entry.url))
             self._table.setItem(row, 2, QTableWidgetItem(entry.login))
-            self._table.setItem(row, 3, QTableWidgetItem("*" * 8))
+            self._table.setItem(row, 3, QTableWidgetItem(entry.source))
+            detail = entry.keepass_path if entry.source == "keepass" else "*" * 8
+            self._table.setItem(row, 4, QTableWidgetItem(detail))
 
     def _add(self) -> None:
         dlg = CredentialDialog(parent=self)

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -32,6 +32,19 @@ class CredentialEntry:
 
 
 @dataclass
+class CredentialSource:
+    """Which backend the sync reads credentials from.
+
+    ``source`` is "json" (the built-in credentials.json managed in the GUI) or
+    "keepass" (an external .kdbx read via its path). The KeePass master password
+    is never stored here - it is prompted at sync time.
+    """
+
+    source: str = "json"  # "json" | "keepass"
+    keepass_path: str = ""
+
+
+@dataclass
 class ConnectorEntry:
     id: str
     type: str  # "garmin" | "strava" | "local_folder"
@@ -92,6 +105,29 @@ class ConfigStore:
     @property
     def _config_path(self) -> Path:
         return self._dir / "config.json"
+
+    @property
+    def _credential_source_path(self) -> Path:
+        return self._dir / "credential_source.json"
+
+    # ------------------------------------------------------------------
+    # Credential source (JSON store vs KeePass)
+    # ------------------------------------------------------------------
+
+    def load_credential_source(self) -> CredentialSource:
+        if not self._credential_source_path.exists():
+            return CredentialSource()
+        raw = json.loads(self._credential_source_path.read_text(encoding="utf-8"))
+        return CredentialSource(
+            source=raw.get("source", "json"),
+            keepass_path=raw.get("keepass_path", ""),
+        )
+
+    def save_credential_source(self, source: CredentialSource) -> None:
+        _atomic_write(
+            self._credential_source_path,
+            {"source": source.source, "keepass_path": source.keepass_path},
+        )
 
     # ------------------------------------------------------------------
     # Credentials

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+from app.core.config import (
+    AppConfig,
+    GarminConnectorConfig,
+    GroupSourceConfig,
+    LocalFolderConnectorConfig,
+    StravaConnectorConfig,
+    SyncGroupConfig,
+)
+from app.credentials.base import CredentialRequest
+
+_DEFAULT_CONFIG_DIR = Path.home() / ".config" / "trainings-sync"
+
+
+# ---------------------------------------------------------------------------
+# GUI data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CredentialEntry:
+    service: str
+    url: str
+    login: str
+    password: str
+
+
+@dataclass
+class ConnectorEntry:
+    id: str
+    type: str  # "garmin" | "strava" | "local_folder"
+    credential_service: str = ""
+    credential_url: str = ""
+    credential_login: str = ""
+    client_id: int = 0
+    folder: str = ""
+
+
+@dataclass
+class GroupSourceEntry:
+    id: str
+    priority: int
+
+
+@dataclass
+class SyncGroupEntry:
+    id: str
+    sources: list[GroupSourceEntry] = field(default_factory=list)
+    destinations: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GuiConfig:
+    connectors: list[ConnectorEntry] = field(default_factory=list)
+    sync_groups: list[SyncGroupEntry] = field(default_factory=list)
+    start: str = ""  # YYYY-MM-DD or empty -> default 2000-01-01 used at sync time
+    end: str = ""  # YYYY-MM-DD or empty -> default today used at sync time
+    force: bool = False
+    skip_wellness: bool = False
+
+
+# ---------------------------------------------------------------------------
+# ConfigStore
+# ---------------------------------------------------------------------------
+
+
+class ConfigStore:
+    """Reads and writes GUI config + credentials to a fixed directory."""
+
+    def __init__(self, config_dir: Path = _DEFAULT_CONFIG_DIR) -> None:
+        self._dir = Path(config_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def config_dir(self) -> Path:
+        return self._dir
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._dir / "cache"
+
+    @property
+    def credentials_path(self) -> Path:
+        return self._dir / "credentials.json"
+
+    @property
+    def _config_path(self) -> Path:
+        return self._dir / "config.json"
+
+    # ------------------------------------------------------------------
+    # Credentials
+    # ------------------------------------------------------------------
+
+    def load_credentials(self) -> list[CredentialEntry]:
+        if not self.credentials_path.exists():
+            return []
+        raw: list[dict] = json.loads(self.credentials_path.read_text(encoding="utf-8"))
+        return [
+            CredentialEntry(
+                service=e["service"],
+                url=e["url"],
+                login=e["login"],
+                password=e["password"],
+            )
+            for e in raw
+        ]
+
+    def save_credentials(self, entries: list[CredentialEntry]) -> None:
+        data = [
+            {
+                "service": e.service,
+                "url": e.url,
+                "login": e.login,
+                "password": e.password,
+            }
+            for e in entries
+        ]
+        _atomic_write(self.credentials_path, data)
+
+    # ------------------------------------------------------------------
+    # GUI config
+    # ------------------------------------------------------------------
+
+    def load_gui_config(self) -> GuiConfig:
+        if not self._config_path.exists():
+            return GuiConfig()
+        raw: dict = json.loads(self._config_path.read_text(encoding="utf-8"))
+        connectors = [_parse_connector_entry(c) for c in raw.get("connectors", [])]
+        sync_groups = [_parse_group_entry(g) for g in raw.get("sync_groups", [])]
+        return GuiConfig(
+            connectors=connectors,
+            sync_groups=sync_groups,
+            start=raw.get("start", ""),
+            end=raw.get("end", ""),
+            force=raw.get("force", False),
+            skip_wellness=raw.get("skip_wellness", False),
+        )
+
+    def save_gui_config(self, config: GuiConfig) -> None:
+        data: dict = {
+            "connectors": [_serialize_connector(c) for c in config.connectors],
+            "sync_groups": [_serialize_group(g) for g in config.sync_groups],
+            "force": config.force,
+            "skip_wellness": config.skip_wellness,
+        }
+        if config.start:
+            data["start"] = config.start
+        if config.end:
+            data["end"] = config.end
+        _atomic_write(self._config_path, data)
+
+    # ------------------------------------------------------------------
+    # Conversion to AppConfig (used by the sync engine)
+    # ------------------------------------------------------------------
+
+    def to_app_config(self, config: GuiConfig) -> AppConfig:
+        connectors = tuple(_connector_to_app(c) for c in config.connectors)
+        sync_groups = tuple(_group_to_app(g) for g in config.sync_groups)
+        start = date.fromisoformat(config.start) if config.start else None
+        end = date.fromisoformat(config.end) if config.end else None
+        return AppConfig(
+            cache_dir=self.cache_dir,
+            connectors=connectors,
+            sync_groups=sync_groups,
+            start=start,
+            end=end,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, data: object) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _parse_connector_entry(raw: dict) -> ConnectorEntry:
+    return ConnectorEntry(
+        id=raw.get("id", ""),
+        type=raw.get("type", ""),
+        credential_service=raw.get("credential_service", ""),
+        credential_url=raw.get("credential_url", ""),
+        credential_login=raw.get("credential_login", ""),
+        client_id=raw.get("client_id", 0),
+        folder=raw.get("folder", ""),
+    )
+
+
+def _parse_group_entry(raw: dict) -> SyncGroupEntry:
+    return SyncGroupEntry(
+        id=raw.get("id", ""),
+        sources=[
+            GroupSourceEntry(id=s["id"], priority=s["priority"])
+            for s in raw.get("sources", [])
+        ],
+        destinations=list(raw.get("destinations", [])),
+    )
+
+
+def _serialize_connector(c: ConnectorEntry) -> dict:
+    d: dict = {"id": c.id, "type": c.type}
+    if c.type == "garmin":
+        d["credential_service"] = c.credential_service
+        d["credential_url"] = c.credential_url
+        if c.credential_login:
+            d["credential_login"] = c.credential_login
+    elif c.type == "strava":
+        d["client_id"] = c.client_id
+        d["credential_service"] = c.credential_service
+        d["credential_url"] = c.credential_url
+    elif c.type == "local_folder":
+        d["folder"] = c.folder
+    return d
+
+
+def _serialize_group(g: SyncGroupEntry) -> dict:
+    return {
+        "id": g.id,
+        "sources": [{"id": s.id, "priority": s.priority} for s in g.sources],
+        "destinations": list(g.destinations),
+    }
+
+
+def _connector_to_app(
+    c: ConnectorEntry,
+) -> GarminConnectorConfig | StravaConnectorConfig | LocalFolderConnectorConfig:
+    if c.type == "garmin":
+        return GarminConnectorConfig(
+            id=c.id,
+            credential=CredentialRequest(
+                service=c.credential_service,
+                url=c.credential_url,
+                login=c.credential_login or None,
+            ),
+        )
+    if c.type == "strava":
+        return StravaConnectorConfig(
+            id=c.id,
+            client_id=c.client_id,
+            credential=CredentialRequest(
+                service=c.credential_service,
+                url=c.credential_url,
+            ),
+        )
+    if c.type == "local_folder":
+        return LocalFolderConnectorConfig(
+            id=c.id,
+            folder=Path(c.folder).expanduser().resolve(),
+        )
+    raise ValueError(f"unknown connector type: {c.type!r}")
+
+
+def _group_to_app(g: SyncGroupEntry) -> SyncGroupConfig:
+    return SyncGroupConfig(
+        id=g.id,
+        sources=tuple(
+            GroupSourceConfig(id=s.id, priority=s.priority) for s in g.sources
+        ),
+        destinations=tuple(g.destinations),
+    )

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -218,6 +218,8 @@ def _serialize_connector(c: ConnectorEntry) -> dict:
         d["client_id"] = c.client_id
         d["credential_service"] = c.credential_service
         d["credential_url"] = c.credential_url
+        if c.credential_login:
+            d["credential_login"] = c.credential_login
     elif c.type == "local_folder":
         d["folder"] = c.folder
     return d
@@ -250,6 +252,7 @@ def _connector_to_app(
             credential=CredentialRequest(
                 service=c.credential_service,
                 url=c.credential_url,
+                login=c.credential_login or None,
             ),
         )
     if c.type == "local_folder":

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -129,16 +129,18 @@ class ConfigStore:
         if not self._config_path.exists():
             return GuiConfig()
         raw: dict = json.loads(self._config_path.read_text(encoding="utf-8"))
-        connectors = [_parse_connector_entry(c) for c in raw.get("connectors", [])]
-        sync_groups = [_parse_group_entry(g) for g in raw.get("sync_groups", [])]
-        return GuiConfig(
-            connectors=connectors,
-            sync_groups=sync_groups,
-            start=raw.get("start", ""),
-            end=raw.get("end", ""),
-            force=raw.get("force", False),
-            skip_wellness=raw.get("skip_wellness", False),
-        )
+        return _parse_gui_config(raw)
+
+    def load_gui_config_from(self, path: Path) -> GuiConfig:
+        """Parse a config JSON file at an arbitrary path.
+
+        Accepts both the GUI's own ``config.json`` and CLI config files; the
+        CLI-only ``cache_dir`` field is ignored (the GUI uses a fixed cache).
+        """
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("config file must contain a JSON object")
+        return _parse_gui_config(raw)
 
     def save_gui_config(self, config: GuiConfig) -> None:
         data: dict = {
@@ -188,6 +190,17 @@ def _parse_credential_entry(raw: dict) -> CredentialEntry:
         url=raw["url"],
         login=raw["login"],
         password=raw["password"],
+    )
+
+
+def _parse_gui_config(raw: dict) -> GuiConfig:
+    return GuiConfig(
+        connectors=[_parse_connector_entry(c) for c in raw.get("connectors", [])],
+        sync_groups=[_parse_group_entry(g) for g in raw.get("sync_groups", [])],
+        start=raw.get("start", ""),
+        end=raw.get("end", ""),
+        force=raw.get("force", False),
+        skip_wellness=raw.get("skip_wellness", False),
     )
 
 

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -49,18 +49,6 @@ class CredentialEntry:
 
 
 @dataclass
-class CredentialSource:
-    """Deprecated global credential-source toggle.
-
-    Superseded by the per-credential ``CredentialEntry.source``; kept
-    temporarily until the global selector is removed.
-    """
-
-    source: str = "json"  # "json" | "keepass"
-    keepass_path: str = ""
-
-
-@dataclass
 class ConnectorEntry:
     id: str
     type: str  # "garmin" | "strava" | "local_folder"
@@ -121,29 +109,6 @@ class ConfigStore:
     @property
     def _config_path(self) -> Path:
         return self._dir / "config.json"
-
-    @property
-    def _credential_source_path(self) -> Path:
-        return self._dir / "credential_source.json"
-
-    # ------------------------------------------------------------------
-    # Credential source (JSON store vs KeePass)
-    # ------------------------------------------------------------------
-
-    def load_credential_source(self) -> CredentialSource:
-        if not self._credential_source_path.exists():
-            return CredentialSource()
-        raw = json.loads(self._credential_source_path.read_text(encoding="utf-8"))
-        return CredentialSource(
-            source=raw.get("source", "json"),
-            keepass_path=raw.get("keepass_path", ""),
-        )
-
-    def save_credential_source(self, source: CredentialSource) -> None:
-        _atomic_write(
-            self._credential_source_path,
-            {"source": source.source, "keepass_path": source.keepass_path},
-        )
 
     # ------------------------------------------------------------------
     # Credentials

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -100,16 +100,14 @@ class ConfigStore:
     def load_credentials(self) -> list[CredentialEntry]:
         if not self.credentials_path.exists():
             return []
-        raw: list[dict] = json.loads(self.credentials_path.read_text(encoding="utf-8"))
-        return [
-            CredentialEntry(
-                service=e["service"],
-                url=e["url"],
-                login=e["login"],
-                password=e["password"],
-            )
-            for e in raw
-        ]
+        return self.load_credentials_from(self.credentials_path)
+
+    def load_credentials_from(self, path: Path) -> list[CredentialEntry]:
+        """Parse a credentials JSON file (CLI/GUI format) at an arbitrary path."""
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            raise ValueError("credentials file must contain a JSON array")
+        return [_parse_credential_entry(e) for e in raw]
 
     def save_credentials(self, entries: list[CredentialEntry]) -> None:
         data = [
@@ -182,6 +180,15 @@ def _atomic_write(path: Path, data: object) -> None:
     tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
     tmp.replace(path)
+
+
+def _parse_credential_entry(raw: dict) -> CredentialEntry:
+    return CredentialEntry(
+        service=raw["service"],
+        url=raw["url"],
+        login=raw["login"],
+        password=raw["password"],
+    )
 
 
 def _parse_connector_entry(raw: dict) -> ConnectorEntry:

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -17,6 +17,13 @@ from app.credentials.base import CredentialRequest
 
 _DEFAULT_CONFIG_DIR = Path.home() / ".config" / "trainings-sync"
 
+# Single source of truth for the connector types the GUI supports. The GUI's
+# type dropdown is built from this, and every entry must be handled by
+# _connector_to_app / _serialize_connector below. To add a new connector,
+# append its type here and extend those two functions (the round-trip test
+# test_every_connector_type_is_convertible enforces the latter).
+CONNECTOR_TYPES: tuple[str, ...] = ("garmin", "strava", "local_folder")
+
 
 # ---------------------------------------------------------------------------
 # GUI data models

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -32,19 +32,28 @@ CONNECTOR_TYPES: tuple[str, ...] = ("garmin", "strava", "local_folder")
 
 @dataclass
 class CredentialEntry:
+    """A single credential account.
+
+    Each account carries its own source: "manual" keeps the password inline;
+    "keepass" resolves the password from an external ``.kdbx`` at sync time
+    (matched by url/login) and stores only the file path here - never the
+    KeePass master password.
+    """
+
     service: str
     url: str
     login: str
-    password: str
+    password: str = ""  # manual source only
+    source: str = "manual"  # "manual" | "keepass"
+    keepass_path: str = ""  # keepass source only
 
 
 @dataclass
 class CredentialSource:
-    """Which backend the sync reads credentials from.
+    """Deprecated global credential-source toggle.
 
-    ``source`` is "json" (the built-in credentials.json managed in the GUI) or
-    "keepass" (an external .kdbx read via its path). The KeePass master password
-    is never stored here - it is prompted at sync time.
+    Superseded by the per-credential ``CredentialEntry.source``; kept
+    temporarily until the global selector is removed.
     """
 
     source: str = "json"  # "json" | "keepass"
@@ -153,16 +162,9 @@ class ConfigStore:
         return [_parse_credential_entry(e) for e in raw]
 
     def save_credentials(self, entries: list[CredentialEntry]) -> None:
-        data = [
-            {
-                "service": e.service,
-                "url": e.url,
-                "login": e.login,
-                "password": e.password,
-            }
-            for e in entries
-        ]
-        _atomic_write(self.credentials_path, data)
+        _atomic_write(
+            self.credentials_path, [_serialize_credential(e) for e in entries]
+        )
 
     # ------------------------------------------------------------------
     # GUI config
@@ -228,12 +230,30 @@ def _atomic_write(path: Path, data: object) -> None:
 
 
 def _parse_credential_entry(raw: dict) -> CredentialEntry:
+    # `source`/`keepass_path` are absent in CLI/legacy files -> treated as
+    # manual credentials, keeping backward compatibility with `--creds-json`.
     return CredentialEntry(
         service=raw["service"],
         url=raw["url"],
         login=raw["login"],
-        password=raw["password"],
+        password=raw.get("password", ""),
+        source=raw.get("source", "manual"),
+        keepass_path=raw.get("keepass_path", ""),
     )
+
+
+def _serialize_credential(e: CredentialEntry) -> dict:
+    d: dict = {
+        "service": e.service,
+        "url": e.url,
+        "login": e.login,
+        "source": e.source,
+    }
+    if e.source == "keepass":
+        d["keepass_path"] = e.keepass_path
+    else:
+        d["password"] = e.password
+    return d
 
 
 def _parse_gui_config(raw: dict) -> GuiConfig:

--- a/app/gui/credential_provider.py
+++ b/app/gui/credential_provider.py
@@ -1,0 +1,88 @@
+"""Credential provider that resolves the GUI's per-account credential entries.
+
+Manual accounts return their inline password; KeePass accounts delegate to a
+KeePassProvider for their .kdbx file (opened with a master password supplied
+per file). Strava token refreshes are written back to manual accounts only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from app.credentials.base import (
+    CredentialProvider,
+    CredentialRequest,
+    Credentials,
+    CredentialsNotFoundError,
+)
+from app.gui.config_store import CredentialEntry
+from app.tracking.tracker import TaskTracker
+
+
+class GuiCredentialProvider(CredentialProvider):
+    def __init__(
+        self,
+        entries: list[CredentialEntry],
+        keepass_passwords: dict[str, str],
+        tracker: TaskTracker,
+        on_manual_update: Callable[[list[CredentialEntry]], None] | None = None,
+    ) -> None:
+        self._entries = entries
+        self._keepass_passwords = keepass_passwords
+        self._tracker = tracker
+        self._on_manual_update = on_manual_update
+        self._keepass_cache: dict[str, CredentialProvider] = {}
+
+    async def get_credentials(self, request: CredentialRequest) -> Credentials:
+        entry = self._match(request)
+        if entry is None:
+            raise CredentialsNotFoundError(request)
+        if entry.source == "keepass":
+            provider = self._keepass_provider(entry.keepass_path)
+            return await provider.get_credentials(request)
+        return await self._get_manual(request, entry)
+
+    def _match(self, request: CredentialRequest) -> CredentialEntry | None:
+        matches = [
+            e
+            for e in self._entries
+            if e.service == request.service
+            and request.url in e.url
+            and (request.login is None or e.login == request.login)
+        ]
+        return matches[0] if matches else None
+
+    def _keepass_provider(self, path: str) -> CredentialProvider:
+        if path not in self._keepass_cache:
+            from app.credentials.keepass import KeePassProvider
+
+            self._keepass_cache[path] = KeePassProvider(
+                path=Path(path).expanduser(),
+                password=self._keepass_passwords.get(path, ""),
+                tracker=self._tracker,
+            )
+        return self._keepass_cache[path]
+
+    async def _get_manual(
+        self, request: CredentialRequest, entry: CredentialEntry
+    ) -> Credentials:
+        task = await self._tracker.add_task(f"Credentials ({request.service})", total=1)
+        await self._tracker.advance(task)
+        await self._tracker.finish(task)
+        return Credentials(login=entry.login, password=entry.password)
+
+    def update_refresh_token(self, request: CredentialRequest, new_token: str) -> None:
+        for entry in self._entries:
+            if (
+                entry.source == "manual"
+                and entry.service == request.service
+                and request.url in entry.url
+                and (request.login is None or entry.login == request.login)
+            ):
+                entry.password = new_token
+                break
+        else:
+            raise CredentialsNotFoundError(request)
+        if self._on_manual_update is not None:
+            self._on_manual_update(self._entries)

--- a/app/gui/credential_provider.py
+++ b/app/gui/credential_provider.py
@@ -20,6 +20,18 @@ from app.gui.config_store import CredentialEntry
 from app.tracking.tracker import TaskTracker
 
 
+def find_credential(
+    entries: list[CredentialEntry], service: str, url: str, login: str | None
+) -> CredentialEntry | None:
+    """Find the credential a connector references (service + url + login)."""
+    matches = [
+        e
+        for e in entries
+        if e.service == service and url in e.url and (not login or e.login == login)
+    ]
+    return matches[0] if matches else None
+
+
 class GuiCredentialProvider(CredentialProvider):
     def __init__(
         self,
@@ -44,14 +56,9 @@ class GuiCredentialProvider(CredentialProvider):
         return await self._get_manual(request, entry)
 
     def _match(self, request: CredentialRequest) -> CredentialEntry | None:
-        matches = [
-            e
-            for e in self._entries
-            if e.service == request.service
-            and request.url in e.url
-            and (request.login is None or e.login == request.login)
-        ]
-        return matches[0] if matches else None
+        return find_credential(
+            self._entries, request.service, request.url, request.login
+        )
 
     def _keepass_provider(self, path: str) -> CredentialProvider:
         if path not in self._keepass_cache:

--- a/app/tracking/gui_renderer.py
+++ b/app/tracking/gui_renderer.py
@@ -1,23 +1,45 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal
+
 from app.tracking.tracker import ProgressRenderer, Task
 
 
+class _RendererSignals(QObject):
+    """Qt signal carrier - kept separate to avoid QObject/ABCMeta metaclass conflict."""
+
+    task_added = Signal(str, object)  # name, total (int | None)
+    progress_updated = Signal(str, int)  # name, progress
+    task_done = Signal(str, list)  # name, warnings
+    task_failed = Signal(str, str)  # name, error
+    task_warning = Signal(str, str)  # name, message
+    total_updated = Signal(str, int)  # name, new_total
+
+
 class GuiRenderer(ProgressRenderer):
-    """Stub - wired to PySide6 widgets in a future commit."""
+    """Bridges TaskTracker events to Qt signals for the GUI sync tab."""
+
+    def __init__(self) -> None:
+        self._signals = _RendererSignals()
+
+    @property
+    def signals(self) -> _RendererSignals:
+        return self._signals
 
     def on_task_added(self, task: Task) -> None:
-        pass
+        self._signals.task_added.emit(task.name, task.total)
 
     def on_progress(self, task: Task) -> None:
-        pass
+        self._signals.progress_updated.emit(task.name, task.progress)
 
     def on_task_done(self, task: Task) -> None:
-        pass
+        self._signals.task_done.emit(task.name, list(task.warnings))
 
     def on_task_failed(self, task: Task) -> None:
-        pass
+        self._signals.task_failed.emit(task.name, task.error or "")
 
     def on_task_warning(self, task: Task, message: str) -> None:
-        pass
+        self._signals.task_warning.emit(task.name, message)
 
     def on_total_updated(self, task: Task) -> None:
-        pass
+        self._signals.total_updated.emit(task.name, task.total or 0)

--- a/app/tracking/gui_renderer.py
+++ b/app/tracking/gui_renderer.py
@@ -12,7 +12,6 @@ class _RendererSignals(QObject):
     progress_updated = Signal(str, int)  # name, progress
     task_done = Signal(str, list)  # name, warnings
     task_failed = Signal(str, str)  # name, error
-    task_warning = Signal(str, str)  # name, message
     total_updated = Signal(str, int)  # name, new_total
 
 
@@ -39,7 +38,7 @@ class GuiRenderer(ProgressRenderer):
         self._signals.task_failed.emit(task.name, task.error or "")
 
     def on_task_warning(self, task: Task, message: str) -> None:
-        self._signals.task_warning.emit(task.name, message)
+        pass  # warnings are accumulated in task.warnings and shown at on_task_done
 
     def on_total_updated(self, task: Task) -> None:
         self._signals.total_updated.emit(task.name, task.total or 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,12 @@ dependencies = [
     "gpxpy>=1.6,<2",
     "urllib3>=2.7.0,<3",
     "idna>=3.15,<4",
+    "pyside6>=6.7,<7",
 ]
 
 [project.scripts]
 trainings-sync = "app.cli:main"
+trainings-sync-gui = "app.gui.app:main"
 
 [dependency-groups]
 dev = [
@@ -30,6 +32,7 @@ dev = [
     "pytest-xdist>=3.8.0,<4",
     "pytest-cov>=7.1.0,<8",
     "pytest-asyncio>=1.3.0,<2",
+    "pytest-qt>=4.4,<5",
 ]
 
 [tool.uv]
@@ -76,7 +79,10 @@ ignore_missing_imports = true
 
 [tool.coverage.run]
 parallel = true
-omit = ["app/tracking/gui_renderer.py"]
+omit = [
+    "app/tracking/gui_renderer.py",
+    "app/gui/app.py",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "S105", "S106"]
+"tests/**/*.py" = ["S101", "S105", "S106", "S108"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -1,0 +1,6 @@
+"""Configure headless Qt for GUI tests."""
+
+import os
+
+# Must be set before QApplication is created.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -105,11 +105,26 @@ def test_credential_dialog_defaults_to_manual_source(qtbot) -> None:
     assert dlg._keepass_row.isHidden()
 
 
+def test_credential_dialog_url_dropdown_presets_and_free_text(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    urls = [dlg._url.itemText(i) for i in range(dlg._url.count())]
+    assert urls == [
+        "https://connect.garmin.com",
+        "https://www.strava.com/api/v3",
+    ]
+    assert dlg._url.isEditable()
+    # A custom URL can still be typed.
+    dlg._service.setText("Custom")
+    dlg._url.setCurrentText("https://example.test/api")
+    assert dlg.result_entry().url == "https://example.test/api"
+
+
 def test_credential_dialog_manual_result(qtbot) -> None:
     dlg = CredentialDialog()
     qtbot.addWidget(dlg)
     dlg._service.setText("Garmin Connect")
-    dlg._url.setText("https://connect.garmin.com")
+    dlg._url.setCurrentText("https://connect.garmin.com")
     dlg._login.setText("me@x")
     dlg._password.setText("secret")
     entry = dlg.result_entry()
@@ -141,7 +156,7 @@ def test_credential_dialog_keepass_result(qtbot) -> None:
     dlg = CredentialDialog()
     qtbot.addWidget(dlg)
     dlg._service.setText("Garmin Connect")
-    dlg._url.setText("https://connect.garmin.com")
+    dlg._url.setCurrentText("https://connect.garmin.com")
     dlg._login.setText("me@x")
     dlg._keepass_radio.setChecked(True)
     dlg._keepass_path.setText("/home/me/db.kdbx")

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -301,6 +301,46 @@ def test_credentials_tab_masks_password(qtbot, store: ConfigStore) -> None:
     assert "supersecret" not in displayed
 
 
+def test_credentials_tab_load_from_file(
+    qtbot, monkeypatch, store: ConfigStore, tmp_path: Path
+) -> None:
+    import json as _json
+
+    from PySide6.QtWidgets import QFileDialog
+
+    src = tmp_path / "creds.json"
+    src.write_text(
+        _json.dumps(
+            [{"service": "Strava", "url": "u", "login": "cs", "password": "rt"}]
+        ),
+        encoding="utf-8",
+    )
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: (str(src), ""))
+    tab._load_from_file()
+
+    assert tab._table.rowCount() == 1
+    assert tab._table.item(0, 0).text() == "Strava"
+    # The imported credentials are persisted to the fixed store location.
+    assert store.load_credentials()[0].service == "Strava"
+
+
+def test_credentials_tab_load_from_file_cancelled_is_noop(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QFileDialog
+
+    store.save_credentials([CredentialEntry("Keep", "u", "l", "p")])
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: ("", ""))
+    tab._load_from_file()
+
+    assert tab._table.rowCount() == 1
+    assert tab._table.item(0, 0).text() == "Keep"
+
+
 # ---------------------------------------------------------------------------
 # TaskRow
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -817,6 +817,45 @@ def test_config_tab_edit_connector_keeping_own_name_is_allowed(
     assert saved[0].folder == "/b"
 
 
+class _FakeGroupDialog:
+    def __init__(self, entry: SyncGroupEntry) -> None:
+        self._entry = entry
+
+    def exec(self) -> int:
+        from PySide6.QtWidgets import QDialog
+
+        return QDialog.DialogCode.Accepted
+
+    def result_entry(self) -> SyncGroupEntry:
+        return self._entry
+
+
+def test_config_tab_add_group_rejects_duplicate_name(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[ConnectorEntry(id="local", type="local_folder", folder="/x")],
+            sync_groups=[SyncGroupEntry(id="g", sources=[], destinations=[])],
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+
+    dupe = SyncGroupEntry(id="g", sources=[], destinations=[])
+    monkeypatch.setattr(gui_app, "SyncGroupDialog", lambda **kw: _FakeGroupDialog(dupe))
+    warned: list[bool] = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(True))
+    tab._add_group()
+
+    assert warned == [True]
+    assert [g.id for g in store.load_gui_config().sync_groups] == ["g"]
+
+
 def test_config_tab_delete_connector_used_in_group_is_blocked(
     qtbot, monkeypatch, store: ConfigStore
 ) -> None:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -680,6 +680,38 @@ def test_sync_worker_logs_and_closes_logger_on_setup_failure(
     assert "Sync run finished" in log_text  # run_end() ran in the finally block
 
 
+def test_sync_worker_keepass_rejects_strava_connectors(
+    qtbot, store: ConfigStore
+) -> None:
+    # KeePass cannot persist Strava refresh tokens, so the combination is
+    # refused (mirroring the CLI's --creds-keepass restriction).
+    store.save_credential_source(
+        CredentialSource(source="keepass", keepass_path="/x/db.kdbx")
+    )
+    gui_config = GuiConfig(
+        connectors=[
+            ConnectorEntry(
+                id="strava",
+                type="strava",
+                credential_service="Strava",
+                credential_url="https://www.strava.com/api/v3",
+                client_id=1,
+            )
+        ],
+        sync_groups=[
+            SyncGroupEntry(
+                id="g",
+                sources=[GroupSourceEntry("strava", 1)],
+                destinations=[],
+            )
+        ],
+    )
+    worker = SyncWorker(store, gui_config, GuiRenderer(), keepass_password="pw")
+
+    with pytest.raises(ValueError, match="does not support Strava"):
+        asyncio.run(worker._async_sync())
+
+
 # ---------------------------------------------------------------------------
 # MainWindow
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -331,6 +331,17 @@ def test_log_dialog_existing_file(qtbot, tmp_path: Path) -> None:
     assert any("line1" in w.toPlainText() for w in texts)
 
 
+def test_log_dialog_uses_fixed_pitch_font(qtbot, tmp_path: Path) -> None:
+    from PySide6.QtGui import QFontDatabase
+    from PySide6.QtWidgets import QTextEdit
+
+    dlg = LogDialog(log_path=tmp_path / "sync.log")
+    qtbot.addWidget(dlg)
+    edit = dlg.findChildren(QTextEdit)[0]
+    mono = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+    assert edit.font().family() == mono.family()
+
+
 # ---------------------------------------------------------------------------
 # SyncWorker
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -481,3 +481,12 @@ def test_main_window_tab_labels(qtbot, store: ConfigStore) -> None:
     assert "Credentials" in labels
     assert "Configuration" in labels
     assert "Sync" in labels
+
+
+def test_main_window_tab_order_sync_first(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tabs = window.centralWidget()
+    labels = [tabs.tabText(i) for i in range(tabs.count())]
+    assert labels == ["Sync", "Configuration", "Credentials"]
+    assert tabs.currentIndex() == 0  # Sync is the default active tab

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -433,8 +433,26 @@ def test_credentials_tab_masks_password(qtbot, store: ConfigStore) -> None:
     store.save_credentials([CredentialEntry("S", "U", "L", "supersecret")])
     tab = CredentialsTab(store)
     qtbot.addWidget(tab)
-    displayed = tab._table.item(0, 3).text()
+    # Column 4 is the secret / KeePass file column.
+    displayed = tab._table.item(0, 4).text()
     assert "supersecret" not in displayed
+
+
+def test_credentials_tab_shows_source_column(qtbot, store: ConfigStore) -> None:
+    store.save_credentials(
+        [
+            CredentialEntry("Manual", "u", "l", "p"),
+            CredentialEntry(
+                "Kp", "u", "l", source="keepass", keepass_path="/x/db.kdbx"
+            ),
+        ]
+    )
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    assert tab._table.item(0, 3).text() == "manual"
+    assert tab._table.item(1, 3).text() == "keepass"
+    # A KeePass credential shows its file path (no secret to mask).
+    assert tab._table.item(1, 4).text() == "/x/db.kdbx"
 
 
 def test_credentials_tab_load_from_file(
@@ -475,44 +493,6 @@ def test_credentials_tab_load_from_file_cancelled_is_noop(
 
     assert tab._table.rowCount() == 1
     assert tab._table.item(0, 0).text() == "Keep"
-
-
-def test_credentials_tab_defaults_to_json_source(qtbot, store: ConfigStore) -> None:
-    tab = CredentialsTab(store)
-    qtbot.addWidget(tab)
-    assert tab._src_json_radio.isChecked()
-    assert tab._keepass_row.isHidden()
-    assert tab._table.isEnabled()
-
-
-def test_credentials_tab_selecting_keepass_persists_and_disables_json(
-    qtbot, store: ConfigStore
-) -> None:
-    tab = CredentialsTab(store)
-    qtbot.addWidget(tab)
-    tab._src_keepass_radio.setChecked(True)
-    tab._keepass_path.setText("/home/me/db.kdbx")
-
-    # JSON management is disabled and the KeePass path row is shown.
-    assert not tab._table.isEnabled()
-    assert not tab._add_btn.isEnabled()
-    assert not tab._keepass_row.isHidden()
-
-    # The choice is persisted.
-    cs = store.load_credential_source()
-    assert cs.source == "keepass"
-    assert cs.keepass_path == "/home/me/db.kdbx"
-
-
-def test_credentials_tab_loads_saved_keepass_source(qtbot, store: ConfigStore) -> None:
-    store.save_credential_source(
-        CredentialSource(source="keepass", keepass_path="/x/db.kdbx")
-    )
-    tab = CredentialsTab(store)
-    qtbot.addWidget(tab)
-    assert tab._src_keepass_radio.isChecked()
-    assert tab._keepass_path.text() == "/x/db.kdbx"
-    assert not tab._table.isEnabled()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -160,6 +160,55 @@ def test_connector_dialog_ok_disabled_until_id_filled(qtbot) -> None:
     assert dlg._ok_btn.isEnabled()
 
 
+def test_connector_dialog_credential_combo_lists_configured_accounts(qtbot) -> None:
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p"),
+        CredentialEntry("Strava", "https://www.strava.com/api/v3", "cs", "rt"),
+    ]
+    dlg = ConnectorDialog(credentials=creds)
+    qtbot.addWidget(dlg)
+    services = [dlg._cred_service.itemText(i) for i in range(dlg._cred_service.count())]
+    assert services == ["Garmin Connect", "Strava"]
+    assert dlg._cred_service.isEditable()
+
+
+def test_connector_dialog_credential_combo_accepts_free_text(qtbot) -> None:
+    dlg = ConnectorDialog(credentials=[])
+    qtbot.addWidget(dlg)
+    dlg._cred_service.setCurrentText("Custom Service")
+    assert dlg.result_entry().credential_service == "Custom Service"
+
+
+def test_connector_dialog_selecting_service_autofills_account(qtbot) -> None:
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p"),
+    ]
+    dlg = ConnectorDialog(credentials=creds)
+    qtbot.addWidget(dlg)
+    dlg._cred_service.setCurrentText("Garmin Connect")
+    entry = dlg.result_entry()
+    assert entry.credential_url == "https://connect.garmin.com"
+    assert entry.credential_login == "me@x"
+
+
+def test_connector_dialog_prefilled_credentials_not_clobbered(qtbot) -> None:
+    # Opening an existing connector must keep its stored URL/login even when a
+    # matching service exists in the credentials list.
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "a@x", "p"),
+    ]
+    existing = ConnectorEntry(
+        id="g",
+        type="garmin",
+        credential_service="Garmin Connect",
+        credential_url="https://connect.garmin.com",
+        credential_login="b@x",
+    )
+    dlg = ConnectorDialog(entry=existing, credentials=creds)
+    qtbot.addWidget(dlg)
+    assert dlg.result_entry().credential_login == "b@x"
+
+
 # ---------------------------------------------------------------------------
 # SyncGroupDialog
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -713,6 +713,67 @@ def test_sync_worker_keepass_rejects_strava_connectors(
 
 
 # ---------------------------------------------------------------------------
+# SyncTab - KeePass master-password prompt
+# ---------------------------------------------------------------------------
+
+
+def _make_sync_tab(store: ConfigStore):
+    from app.gui.app import SyncTab
+
+    return SyncTab(store, ConfigTab(store))
+
+
+def test_sync_tab_prompts_keepass_password(qtbot, monkeypatch, store) -> None:
+    from PySide6.QtWidgets import QInputDialog
+
+    store.save_credential_source(
+        CredentialSource(source="keepass", keepass_path="/x.kdbx")
+    )
+    tab = _make_sync_tab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("secret-pw", True))
+    monkeypatch.setattr(SyncWorker, "start", lambda self: None)
+
+    tab._run_sync()
+    assert tab._worker is not None
+    assert tab._worker._keepass_password == "secret-pw"
+
+
+def test_sync_tab_keepass_cancel_aborts_run(qtbot, monkeypatch, store) -> None:
+    from PySide6.QtWidgets import QInputDialog
+
+    store.save_credential_source(
+        CredentialSource(source="keepass", keepass_path="/x.kdbx")
+    )
+    tab = _make_sync_tab(store)
+    qtbot.addWidget(tab)
+    started: list[bool] = []
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("", False))
+    monkeypatch.setattr(SyncWorker, "start", lambda self: started.append(True))
+
+    tab._run_sync()
+    assert tab._worker is None
+    assert started == []
+
+
+def test_sync_tab_json_source_does_not_prompt(qtbot, monkeypatch, store) -> None:
+    from PySide6.QtWidgets import QInputDialog
+
+    tab = _make_sync_tab(store)
+    qtbot.addWidget(tab)
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise AssertionError("must not prompt for the JSON source")
+
+    monkeypatch.setattr(QInputDialog, "getText", _boom)
+    monkeypatch.setattr(SyncWorker, "start", lambda self: None)
+
+    tab._run_sync()
+    assert tab._worker is not None
+    assert tab._worker._keepass_password is None
+
+
+# ---------------------------------------------------------------------------
 # MainWindow
 # ---------------------------------------------------------------------------
 

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -26,6 +26,7 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
+    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -389,6 +390,44 @@ def test_credentials_tab_load_from_file_cancelled_is_noop(
 
     assert tab._table.rowCount() == 1
     assert tab._table.item(0, 0).text() == "Keep"
+
+
+def test_credentials_tab_defaults_to_json_source(qtbot, store: ConfigStore) -> None:
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    assert tab._src_json_radio.isChecked()
+    assert tab._keepass_row.isHidden()
+    assert tab._table.isEnabled()
+
+
+def test_credentials_tab_selecting_keepass_persists_and_disables_json(
+    qtbot, store: ConfigStore
+) -> None:
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    tab._src_keepass_radio.setChecked(True)
+    tab._keepass_path.setText("/home/me/db.kdbx")
+
+    # JSON management is disabled and the KeePass path row is shown.
+    assert not tab._table.isEnabled()
+    assert not tab._add_btn.isEnabled()
+    assert not tab._keepass_row.isHidden()
+
+    # The choice is persisted.
+    cs = store.load_credential_source()
+    assert cs.source == "keepass"
+    assert cs.keepass_path == "/home/me/db.kdbx"
+
+
+def test_credentials_tab_loads_saved_keepass_source(qtbot, store: ConfigStore) -> None:
+    store.save_credential_source(
+        CredentialSource(source="keepass", keepass_path="/x/db.kdbx")
+    )
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    assert tab._src_keepass_radio.isChecked()
+    assert tab._keepass_path.text() == "/x/db.kdbx"
+    assert not tab._table.isEnabled()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -10,6 +10,7 @@ import pytest
 from PySide6.QtCore import Qt
 
 from app.gui.app import (
+    ConfigTab,
     ConnectorDialog,
     CredentialDialog,
     CredentialsTab,
@@ -386,6 +387,47 @@ def test_log_dialog_uses_fixed_pitch_font(qtbot, tmp_path: Path) -> None:
     edit = dlg.findChildren(QTextEdit)[0]
     mono = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
     assert edit.font().family() == mono.family()
+
+
+# ---------------------------------------------------------------------------
+# ConfigTab
+# ---------------------------------------------------------------------------
+
+
+def test_config_tab_delete_connector_prunes_group_references(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(id="garmin", type="garmin"),
+                ConnectorEntry(id="local", type="local_folder", folder="/data"),
+            ],
+            sync_groups=[
+                SyncGroupEntry(
+                    id="g",
+                    sources=[GroupSourceEntry("garmin", 1)],
+                    destinations=["local"],
+                )
+            ],
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        lambda *a, **k: QMessageBox.StandardButton.Yes,
+    )
+    tab._conn_list.setCurrentRow(0)  # garmin
+    tab._delete_connector()
+
+    reloaded = store.load_gui_config()
+    assert [c.id for c in reloaded.connectors] == ["local"]
+    assert reloaded.sync_groups[0].sources == []
+    assert reloaded.sync_groups[0].destinations == ["local"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -184,11 +184,13 @@ def test_connector_dialog_prefilled_strava(qtbot) -> None:
         credential_url="https://www.strava.com/api/v3",
         client_id=12345,
     )
-    dlg = ConnectorDialog(entry=existing)
+    creds = [CredentialEntry("Strava", "https://www.strava.com/api/v3", "cs", "rt")]
+    dlg = ConnectorDialog(entry=existing, credentials=creds)
     qtbot.addWidget(dlg)
     entry = dlg.result_entry()
     assert entry.type == "strava"
     assert entry.client_id == 12345
+    assert entry.credential_service == "Strava"
 
 
 def test_connector_dialog_local_folder(qtbot) -> None:
@@ -216,11 +218,31 @@ def test_connector_dialog_type_change_shows_strava_client_id(qtbot) -> None:
     assert not dlg._client_id_spin.isHidden()
 
 
-def test_connector_dialog_ok_disabled_until_id_filled(qtbot) -> None:
-    dlg = ConnectorDialog()
+def test_connector_dialog_ok_needs_name_and_credential(qtbot) -> None:
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p")
+    ]
+    dlg = ConnectorDialog(credentials=creds)
     qtbot.addWidget(dlg)
+    # A credential is auto-selected (first item), so only the name is missing.
     assert not dlg._ok_btn.isEnabled()
     dlg._id.setText("garmin")
+    assert dlg._ok_btn.isEnabled()
+
+
+def test_connector_dialog_ok_blocked_without_any_credential(qtbot) -> None:
+    # garmin/strava require a credential; with none configured OK stays disabled.
+    dlg = ConnectorDialog(credentials=[])
+    qtbot.addWidget(dlg)
+    dlg._id.setText("garmin")
+    assert not dlg._ok_btn.isEnabled()
+
+
+def test_connector_dialog_local_folder_needs_no_credential(qtbot) -> None:
+    dlg = ConnectorDialog(credentials=[])
+    qtbot.addWidget(dlg)
+    dlg._type.setCurrentText("local_folder")
+    dlg._id.setText("local")
     assert dlg._ok_btn.isEnabled()
 
 
@@ -231,56 +253,30 @@ def test_connector_dialog_credential_combo_lists_configured_accounts(qtbot) -> N
     ]
     dlg = ConnectorDialog(credentials=creds)
     qtbot.addWidget(dlg)
-    services = [dlg._cred_service.itemText(i) for i in range(dlg._cred_service.count())]
-    assert services == ["Garmin Connect", "Strava"]
-    assert dlg._cred_service.isEditable()
+    labels = [dlg._cred_combo.itemText(i) for i in range(dlg._cred_combo.count())]
+    assert labels == ["Garmin Connect (me@x)", "Strava (cs)"]
+    # The combo is a strict picker, not free-text.
+    assert not dlg._cred_combo.isEditable()
 
 
-def test_connector_dialog_credential_combo_accepts_free_text(qtbot) -> None:
-    dlg = ConnectorDialog(credentials=[])
-    qtbot.addWidget(dlg)
-    dlg._cred_service.setCurrentText("Custom Service")
-    assert dlg.result_entry().credential_service == "Custom Service"
-
-
-def test_connector_dialog_selecting_service_autofills_account(qtbot) -> None:
-    creds = [
-        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p"),
-    ]
-    dlg = ConnectorDialog(credentials=creds)
-    qtbot.addWidget(dlg)
-    dlg._cred_service.setCurrentText("Garmin Connect")
-    entry = dlg.result_entry()
-    assert entry.credential_url == "https://connect.garmin.com"
-    assert entry.credential_login == "me@x"
-
-
-def test_connector_dialog_url_follows_selected_service(qtbot) -> None:
-    # The URL belongs to the account, so it must track the chosen service and
-    # never be an independent choice that could mismatch it.
-    from PySide6.QtWidgets import QLineEdit
-
+def test_connector_dialog_selecting_credential_fills_service_url_login(qtbot) -> None:
     creds = [
         CredentialEntry("Garmin Connect", "https://connect.garmin.com", "g@x", "p"),
         CredentialEntry("Strava", "https://www.strava.com/api/v3", "cs", "rt"),
     ]
     dlg = ConnectorDialog(credentials=creds)
     qtbot.addWidget(dlg)
-    # URL is a derived read-only field, not a cross-service dropdown.
-    assert isinstance(dlg._cred_url, QLineEdit)
-    assert dlg._cred_url.isReadOnly()
-
-    dlg._cred_service.setCurrentText("Strava")
-    assert dlg.result_entry().credential_url == "https://www.strava.com/api/v3"
-    dlg._cred_service.setCurrentText("Garmin Connect")
-    assert dlg.result_entry().credential_url == "https://connect.garmin.com"
+    dlg._cred_combo.setCurrentIndex(1)  # Strava
+    entry = dlg.result_entry()
+    assert entry.credential_service == "Strava"
+    assert entry.credential_url == "https://www.strava.com/api/v3"
+    assert entry.credential_login == "cs"
 
 
-def test_connector_dialog_prefilled_credentials_not_clobbered(qtbot) -> None:
-    # Opening an existing connector must keep its stored URL/login even when a
-    # matching service exists in the credentials list.
+def test_connector_dialog_preselects_existing_credential(qtbot) -> None:
     creds = [
         CredentialEntry("Garmin Connect", "https://connect.garmin.com", "a@x", "p"),
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "b@x", "p"),
     ]
     existing = ConnectorEntry(
         id="g",

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -126,6 +126,17 @@ def test_credential_dialog_keepass_switches_fields(qtbot) -> None:
     assert dlg._password.isHidden()
 
 
+def test_credential_dialog_keepass_requires_path(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    dlg._service.setText("Garmin Connect")
+    assert dlg._ok_btn.isEnabled()  # manual: service is enough
+    dlg._keepass_radio.setChecked(True)
+    assert not dlg._ok_btn.isEnabled()  # keepass without a file path
+    dlg._keepass_path.setText("/x/db.kdbx")
+    assert dlg._ok_btn.isEnabled()
+
+
 def test_credential_dialog_keepass_result(qtbot) -> None:
     dlg = CredentialDialog()
     qtbot.addWidget(dlg)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -342,6 +342,86 @@ def test_credentials_tab_load_from_file_cancelled_is_noop(
 
 
 # ---------------------------------------------------------------------------
+# ConfigTab - load from file
+# ---------------------------------------------------------------------------
+
+# Format mirrors config/config.strava-and-garmin.json but with fake values.
+_SAMPLE_CONFIG = {
+    "cache_dir": ".cache",
+    "start": "2026-06-10",
+    "connectors": [
+        {
+            "id": "garmin",
+            "type": "garmin",
+            "credential_service": "Garmin Connect",
+            "credential_url": "https://connect.garmin.com",
+            "credential_login": "rider@example.com",
+        },
+        {
+            "id": "strava",
+            "type": "strava",
+            "client_id": 12345,
+            "credential_service": "Strava",
+            "credential_url": "https://www.strava.com/api/v3",
+        },
+        {"id": "local", "type": "local_folder", "folder": "/tmp/trainings"},
+    ],
+    "sync_groups": [
+        {
+            "id": "strava-to-garmin",
+            "sources": [{"id": "strava", "priority": 1}],
+            "destinations": ["garmin"],
+        },
+        {
+            "id": "garmin-and-strava-to-local",
+            "sources": [
+                {"id": "garmin", "priority": 1},
+                {"id": "strava", "priority": 2},
+            ],
+            "destinations": ["local"],
+        },
+    ],
+}
+
+
+def test_config_tab_load_from_file(
+    qtbot, monkeypatch, store: ConfigStore, tmp_path: Path
+) -> None:
+    import json as _json
+
+    from PySide6.QtWidgets import QFileDialog
+
+    src = tmp_path / "config.strava-and-garmin.json"
+    src.write_text(_json.dumps(_SAMPLE_CONFIG), encoding="utf-8")
+
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: (str(src), ""))
+    tab._load_from_file()
+
+    assert tab._conn_list.count() == 3
+    assert tab._grp_list.count() == 2
+    assert tab._use_start.isChecked()
+    assert tab._start_date.date().toString("yyyy-MM-dd") == "2026-06-10"
+    # The imported config is persisted to the fixed store location.
+    reloaded = store.load_gui_config()
+    assert [c.id for c in reloaded.connectors] == ["garmin", "strava", "local"]
+
+
+def test_config_tab_load_from_file_cancelled_is_noop(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QFileDialog
+
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: ("", ""))
+    tab._load_from_file()
+
+    assert tab._conn_list.count() == 0
+
+
+# ---------------------------------------------------------------------------
 # TaskRow
 # ---------------------------------------------------------------------------
 

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -192,6 +192,20 @@ def test_sync_group_dialog_prefilled(qtbot) -> None:
     assert entry.destinations == ["local"]
 
 
+def test_sync_group_dialog_source_id_with_colon(qtbot) -> None:
+    # Connector ids may contain a colon; the source must round-trip intact.
+    existing = SyncGroupEntry(
+        id="grp",
+        sources=[GroupSourceEntry("garmin:eu", 3)],
+        destinations=[],
+    )
+    dlg = SyncGroupDialog(connector_ids=["garmin:eu"], entry=existing)
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.sources[0].id == "garmin:eu"
+    assert entry.sources[0].priority == 3
+
+
 # ---------------------------------------------------------------------------
 # CredentialsTab
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -20,6 +20,7 @@ from app.gui.app import (
     SyncWorker,
     TaskRow,
     _parse_date_or_default,
+    make_app_icon,
 )
 from app.gui.config_store import (
     ConfigStore,
@@ -630,3 +631,20 @@ def test_main_window_starts_wide_enough_for_sync_rows(
     # Wide default so the Sync tab's long task rows fit without a horizontal
     # scrollbar on startup.
     assert window.width() >= 1200
+
+
+def test_main_window_has_window_icon(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    assert not window.windowIcon().isNull()
+
+
+# ---------------------------------------------------------------------------
+# Application icon
+# ---------------------------------------------------------------------------
+
+
+def test_make_app_icon_renders(qtbot) -> None:
+    icon = make_app_icon(64)
+    assert not icon.isNull()
+    assert not icon.pixmap(64, 64).isNull()

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -610,3 +610,13 @@ def test_main_window_tab_order_sync_first(qtbot, store: ConfigStore) -> None:
     labels = [tabs.tabText(i) for i in range(tabs.count())]
     assert labels == ["Sync", "Configuration", "Credentials"]
     assert tabs.currentIndex() == 0  # Sync is the default active tab
+
+
+def test_main_window_starts_wide_enough_for_sync_rows(
+    qtbot, store: ConfigStore
+) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    # Wide default so the Sync tab's long task rows fit without a horizontal
+    # scrollbar on startup.
+    assert window.width() >= 1200

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from app.gui.app import (
     LogDialog,
     MainWindow,
     SyncGroupDialog,
+    SyncWorker,
     TaskRow,
     _parse_date_or_default,
 )
@@ -23,8 +25,10 @@ from app.gui.config_store import (
     ConnectorEntry,
     CredentialEntry,
     GroupSourceEntry,
+    GuiConfig,
     SyncGroupEntry,
 )
+from app.tracking.gui_renderer import GuiRenderer
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -325,6 +329,37 @@ def test_log_dialog_existing_file(qtbot, tmp_path: Path) -> None:
 
     texts = dlg.findChildren(QTextEdit)
     assert any("line1" in w.toPlainText() for w in texts)
+
+
+# ---------------------------------------------------------------------------
+# SyncWorker
+# ---------------------------------------------------------------------------
+
+
+def test_sync_worker_logs_and_closes_logger_on_setup_failure(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    # An error raised while building the pipeline must still be written to
+    # sync.log and the logger must be closed (no dangling file handler).
+    import app.core.connector_factory as connector_factory
+
+    async def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("kaboom during build")
+
+    monkeypatch.setattr(connector_factory, "build_connectors", _boom)
+
+    gui_config = GuiConfig(
+        connectors=[ConnectorEntry(id="g", type="garmin")],
+        sync_groups=[],
+    )
+    worker = SyncWorker(store, gui_config, GuiRenderer())
+
+    with pytest.raises(RuntimeError, match="kaboom during build"):
+        asyncio.run(worker._async_sync())
+
+    log_text = (store.cache_dir / "sync.log").read_text(encoding="utf-8")
+    assert "kaboom during build" in log_text
+    assert "Sync run finished" in log_text  # run_end() ran in the finally block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -754,6 +754,69 @@ def _config_with_group(store: ConfigStore) -> None:
     )
 
 
+class _FakeConnectorDialog:
+    def __init__(self, entry: ConnectorEntry) -> None:
+        self._entry = entry
+
+    def exec(self) -> int:
+        from PySide6.QtWidgets import QDialog
+
+        return QDialog.DialogCode.Accepted
+
+    def result_entry(self) -> ConnectorEntry:
+        return self._entry
+
+
+def test_config_tab_add_connector_rejects_duplicate_name(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(connectors=[ConnectorEntry(id="garmin", type="local_folder")])
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+
+    dupe = ConnectorEntry(id="garmin", type="local_folder", folder="/x")
+    monkeypatch.setattr(
+        gui_app, "ConnectorDialog", lambda **kw: _FakeConnectorDialog(dupe)
+    )
+    warned: list[bool] = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(True))
+    tab._add_connector()
+
+    assert warned == [True]
+    assert [c.id for c in store.load_gui_config().connectors] == ["garmin"]
+
+
+def test_config_tab_edit_connector_keeping_own_name_is_allowed(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[ConnectorEntry(id="garmin", type="local_folder", folder="/a")]
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+
+    updated = ConnectorEntry(id="garmin", type="local_folder", folder="/b")
+    monkeypatch.setattr(
+        gui_app, "ConnectorDialog", lambda **kw: _FakeConnectorDialog(updated)
+    )
+    tab._conn_list.setCurrentRow(0)
+    tab._edit_connector()
+
+    saved = store.load_gui_config().connectors
+    assert len(saved) == 1
+    assert saved[0].folder == "/b"
+
+
 def test_config_tab_delete_connector_used_in_group_is_blocked(
     qtbot, monkeypatch, store: ConfigStore
 ) -> None:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -371,12 +371,27 @@ def test_sync_group_dialog_prefilled(qtbot) -> None:
     assert entry.destinations == ["local"]
 
 
-def test_sync_group_dialog_ok_disabled_until_id_filled(qtbot) -> None:
+def test_sync_group_dialog_ok_needs_name_and_source(qtbot) -> None:
     dlg = SyncGroupDialog(connector_ids=["garmin"])
     qtbot.addWidget(dlg)
     assert not dlg._ok_btn.isEnabled()
     dlg._id.setText("my-group")
+    assert not dlg._ok_btn.isEnabled()  # still no source
+    dlg._src_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
     assert dlg._ok_btn.isEnabled()
+
+
+def test_sync_group_dialog_ok_disabled_after_removing_last_source(qtbot) -> None:
+    existing = SyncGroupEntry(
+        id="g", sources=[GroupSourceEntry("garmin", 1)], destinations=[]
+    )
+    dlg = SyncGroupDialog(connector_ids=["garmin"], entry=existing)
+    qtbot.addWidget(dlg)
+    assert dlg._ok_btn.isEnabled()
+    dlg._sources_widget.setCurrentRow(0)
+    qtbot.mouseClick(dlg._src_del_btn, Qt.MouseButton.LeftButton)
+    assert not dlg._ok_btn.isEnabled()
 
 
 def test_sync_group_dialog_ignores_duplicate_source(qtbot) -> None:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -86,10 +86,7 @@ def test_credential_dialog_password_echo_hidden(qtbot) -> None:
 
     dlg = CredentialDialog()
     qtbot.addWidget(dlg)
-    # The last QLineEdit in the dialog is the password field.
-    fields = dlg.findChildren(QLineEdit)
-    pw = fields[-1]
-    assert pw.echoMode() == QLineEdit.EchoMode.Password
+    assert dlg._password.echoMode() == QLineEdit.EchoMode.Password
 
 
 def test_credential_dialog_ok_disabled_until_service_filled(qtbot) -> None:
@@ -98,6 +95,64 @@ def test_credential_dialog_ok_disabled_until_service_filled(qtbot) -> None:
     assert not dlg._ok_btn.isEnabled()
     dlg._service.setText("Garmin Connect")
     assert dlg._ok_btn.isEnabled()
+
+
+def test_credential_dialog_defaults_to_manual_source(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    assert dlg._manual_radio.isChecked()
+    # isHidden() reflects the explicit hidden flag regardless of parent showing.
+    assert not dlg._password.isHidden()
+    assert dlg._keepass_row.isHidden()
+
+
+def test_credential_dialog_manual_result(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    dlg._service.setText("Garmin Connect")
+    dlg._url.setText("https://connect.garmin.com")
+    dlg._login.setText("me@x")
+    dlg._password.setText("secret")
+    entry = dlg.result_entry()
+    assert entry.source == "manual"
+    assert entry.password == "secret"
+    assert entry.keepass_path == ""
+
+
+def test_credential_dialog_keepass_switches_fields(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    dlg._keepass_radio.setChecked(True)
+    assert not dlg._keepass_row.isHidden()
+    assert dlg._password.isHidden()
+
+
+def test_credential_dialog_keepass_result(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    dlg._service.setText("Garmin Connect")
+    dlg._url.setText("https://connect.garmin.com")
+    dlg._login.setText("me@x")
+    dlg._keepass_radio.setChecked(True)
+    dlg._keepass_path.setText("/home/me/db.kdbx")
+    entry = dlg.result_entry()
+    assert entry.source == "keepass"
+    assert entry.keepass_path == "/home/me/db.kdbx"
+    assert entry.password == ""
+
+
+def test_credential_dialog_prefilled_keepass(qtbot) -> None:
+    existing = CredentialEntry(
+        "Garmin Connect",
+        "https://connect.garmin.com",
+        "me@x",
+        source="keepass",
+        keepass_path="/x/db.kdbx",
+    )
+    dlg = CredentialDialog(entry=existing)
+    qtbot.addWidget(dlg)
+    assert dlg._keepass_radio.isChecked()
+    assert dlg._keepass_path.text() == "/x/db.kdbx"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -26,7 +26,6 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
-    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -748,10 +747,18 @@ def test_sync_worker_logs_and_closes_logger_on_setup_failure(
 def test_sync_worker_keepass_rejects_strava_connectors(
     qtbot, store: ConfigStore
 ) -> None:
-    # KeePass cannot persist Strava refresh tokens, so the combination is
-    # refused (mirroring the CLI's --creds-keepass restriction).
-    store.save_credential_source(
-        CredentialSource(source="keepass", keepass_path="/x/db.kdbx")
+    # A Strava connector backed by a KeePass credential is refused, since a
+    # rotated refresh token cannot be written back to a .kdbx.
+    store.save_credentials(
+        [
+            CredentialEntry(
+                "Strava",
+                "https://www.strava.com/api/v3",
+                "cs",
+                source="keepass",
+                keepass_path="/x/db.kdbx",
+            )
+        ]
     )
     gui_config = GuiConfig(
         connectors=[
@@ -760,6 +767,7 @@ def test_sync_worker_keepass_rejects_strava_connectors(
                 type="strava",
                 credential_service="Strava",
                 credential_url="https://www.strava.com/api/v3",
+                credential_login="cs",
                 client_id=1,
             )
         ],
@@ -771,9 +779,11 @@ def test_sync_worker_keepass_rejects_strava_connectors(
             )
         ],
     )
-    worker = SyncWorker(store, gui_config, GuiRenderer(), keepass_password="pw")
+    worker = SyncWorker(
+        store, gui_config, GuiRenderer(), keepass_passwords={"/x/db.kdbx": "pw"}
+    )
 
-    with pytest.raises(ValueError, match="does not support Strava"):
+    with pytest.raises(ValueError, match="does not support KeePass"):
         asyncio.run(worker._async_sync())
 
 
@@ -788,12 +798,37 @@ def _make_sync_tab(store: ConfigStore):
     return SyncTab(store, ConfigTab(store))
 
 
+def _keepass_garmin_config(store: ConfigStore, kdbx: str) -> None:
+    store.save_credentials(
+        [
+            CredentialEntry(
+                "Garmin Connect",
+                "https://connect.garmin.com",
+                "me@x",
+                source="keepass",
+                keepass_path=kdbx,
+            )
+        ]
+    )
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(
+                    id="garmin",
+                    type="garmin",
+                    credential_service="Garmin Connect",
+                    credential_url="https://connect.garmin.com",
+                    credential_login="me@x",
+                )
+            ],
+        )
+    )
+
+
 def test_sync_tab_prompts_keepass_password(qtbot, monkeypatch, store) -> None:
     from PySide6.QtWidgets import QInputDialog
 
-    store.save_credential_source(
-        CredentialSource(source="keepass", keepass_path="/x.kdbx")
-    )
+    _keepass_garmin_config(store, "/x.kdbx")
     tab = _make_sync_tab(store)
     qtbot.addWidget(tab)
     monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("secret-pw", True))
@@ -801,15 +836,71 @@ def test_sync_tab_prompts_keepass_password(qtbot, monkeypatch, store) -> None:
 
     tab._run_sync()
     assert tab._worker is not None
-    assert tab._worker._keepass_password == "secret-pw"
+    assert tab._worker._keepass_passwords == {"/x.kdbx": "secret-pw"}
+
+
+def test_sync_tab_prompts_once_per_distinct_kdbx(qtbot, monkeypatch, store) -> None:
+    from PySide6.QtWidgets import QInputDialog
+
+    # Two connectors sharing one .kdbx must prompt only once.
+    store.save_credentials(
+        [
+            CredentialEntry(
+                "Garmin Connect",
+                "https://connect.garmin.com",
+                "me@x",
+                source="keepass",
+                keepass_path="/shared.kdbx",
+            ),
+            CredentialEntry(
+                "Other",
+                "https://other.example",
+                "u",
+                source="keepass",
+                keepass_path="/shared.kdbx",
+            ),
+        ]
+    )
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(
+                    id="garmin",
+                    type="garmin",
+                    credential_service="Garmin Connect",
+                    credential_url="https://connect.garmin.com",
+                    credential_login="me@x",
+                ),
+                ConnectorEntry(
+                    id="other",
+                    type="garmin",
+                    credential_service="Other",
+                    credential_url="https://other.example",
+                    credential_login="u",
+                ),
+            ],
+        )
+    )
+    tab = _make_sync_tab(store)
+    qtbot.addWidget(tab)
+    prompts: list[str] = []
+
+    def _get_text(_parent, _title, label, *a, **k):
+        prompts.append(label)
+        return ("pw", True)
+
+    monkeypatch.setattr(QInputDialog, "getText", _get_text)
+    monkeypatch.setattr(SyncWorker, "start", lambda self: None)
+
+    tab._run_sync()
+    assert len(prompts) == 1
+    assert tab._worker._keepass_passwords == {"/shared.kdbx": "pw"}
 
 
 def test_sync_tab_keepass_cancel_aborts_run(qtbot, monkeypatch, store) -> None:
     from PySide6.QtWidgets import QInputDialog
 
-    store.save_credential_source(
-        CredentialSource(source="keepass", keepass_path="/x.kdbx")
-    )
+    _keepass_garmin_config(store, "/x.kdbx")
     tab = _make_sync_tab(store)
     qtbot.addWidget(tab)
     started: list[bool] = []
@@ -821,21 +912,22 @@ def test_sync_tab_keepass_cancel_aborts_run(qtbot, monkeypatch, store) -> None:
     assert started == []
 
 
-def test_sync_tab_json_source_does_not_prompt(qtbot, monkeypatch, store) -> None:
+def test_sync_tab_manual_credentials_do_not_prompt(qtbot, monkeypatch, store) -> None:
     from PySide6.QtWidgets import QInputDialog
 
+    store.save_credentials([CredentialEntry("Garmin Connect", "u", "me@x", "pw")])
     tab = _make_sync_tab(store)
     qtbot.addWidget(tab)
 
     def _boom(*_a: object, **_k: object) -> object:
-        raise AssertionError("must not prompt for the JSON source")
+        raise AssertionError("must not prompt when no KeePass credentials are used")
 
     monkeypatch.setattr(QInputDialog, "getText", _boom)
     monkeypatch.setattr(SyncWorker, "start", lambda self: None)
 
     tab._run_sync()
     assert tab._worker is not None
-    assert tab._worker._keepass_password is None
+    assert tab._worker._keepass_passwords == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -89,6 +89,14 @@ def test_credential_dialog_password_echo_hidden(qtbot) -> None:
     assert pw.echoMode() == QLineEdit.EchoMode.Password
 
 
+def test_credential_dialog_ok_disabled_until_service_filled(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    assert not dlg._ok_btn.isEnabled()
+    dlg._service.setText("Garmin Connect")
+    assert dlg._ok_btn.isEnabled()
+
+
 # ---------------------------------------------------------------------------
 # ConnectorDialog
 # ---------------------------------------------------------------------------
@@ -140,6 +148,14 @@ def test_connector_dialog_type_change_shows_strava_client_id(qtbot) -> None:
     qtbot.addWidget(dlg)
     dlg._type.setCurrentText("strava")
     assert not dlg._client_id_spin.isHidden()
+
+
+def test_connector_dialog_ok_disabled_until_id_filled(qtbot) -> None:
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    assert not dlg._ok_btn.isEnabled()
+    dlg._id.setText("garmin")
+    assert dlg._ok_btn.isEnabled()
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +210,14 @@ def test_sync_group_dialog_prefilled(qtbot) -> None:
     entry = dlg.result_entry()
     assert entry.id == "grp"
     assert entry.destinations == ["local"]
+
+
+def test_sync_group_dialog_ok_disabled_until_id_filled(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin"])
+    qtbot.addWidget(dlg)
+    assert not dlg._ok_btn.isEnabled()
+    dlg._id.setText("my-group")
+    assert dlg._ok_btn.isEnabled()
 
 
 def test_sync_group_dialog_ignores_duplicate_source(qtbot) -> None:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -449,6 +449,16 @@ def test_task_row_mark_done_no_warnings(qtbot) -> None:
     assert row._bar.value() == row._bar.maximum()
 
 
+def test_task_row_status_label_fits_ok_tag(qtbot) -> None:
+    row = TaskRow("Task", total=5)
+    qtbot.addWidget(row)
+    row.mark_done([])
+    # The fixed status width must accommodate the full "[OK]" tag so the
+    # closing bracket is not clipped.
+    needed = row._status.fontMetrics().horizontalAdvance("[OK]")
+    assert row._status.minimumWidth() >= needed
+
+
 def test_task_row_mark_done_with_warnings(qtbot) -> None:
     row = TaskRow("Task", total=5)
     qtbot.addWidget(row)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -238,6 +238,30 @@ def test_connector_dialog_local_folder(qtbot) -> None:
     assert entry.folder == "/data"
 
 
+def test_connector_dialog_folder_browse_fills_path(qtbot, monkeypatch) -> None:
+    from PySide6.QtWidgets import QFileDialog
+
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    dlg._type.setCurrentText("local_folder")
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *a, **k: "/chosen/folder"
+    )
+    dlg._browse_folder()
+    assert dlg._folder.text() == "/chosen/folder"
+
+
+def test_connector_dialog_folder_browse_cancel_keeps_path(qtbot, monkeypatch) -> None:
+    from PySide6.QtWidgets import QFileDialog
+
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    dlg._folder.setText("/keep")
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: "")
+    dlg._browse_folder()
+    assert dlg._folder.text() == "/keep"
+
+
 def test_connector_dialog_local_folder_carries_no_credential(qtbot) -> None:
     # Even with credentials configured (and auto-selected in the combo), a
     # local_folder connector must not reference any credential.

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -673,11 +673,7 @@ def test_log_dialog_uses_fixed_pitch_font(qtbot, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_config_tab_delete_connector_prunes_group_references(
-    qtbot, monkeypatch, store: ConfigStore
-) -> None:
-    from PySide6.QtWidgets import QMessageBox
-
+def _config_with_group(store: ConfigStore) -> None:
     store.save_gui_config(
         GuiConfig(
             connectors=[
@@ -693,20 +689,48 @@ def test_config_tab_delete_connector_prunes_group_references(
             ],
         )
     )
+
+
+def test_config_tab_delete_connector_used_in_group_is_blocked(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    _config_with_group(store)
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    warned: dict[str, str] = {}
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda _s, title, text, *a, **k: warned.update(t=text)
+    )
+    tab._conn_list.setCurrentRow(0)  # garmin - used as a source in group "g"
+    tab._delete_connector()
+
+    # The connector is kept and the warning names the offending group.
+    assert [c.id for c in store.load_gui_config().connectors] == ["garmin", "local"]
+    assert "'g'" in warned["t"]
+
+
+def test_config_tab_delete_unused_connector_succeeds(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    _config_with_group(store)
+    # Remove the group so "local" becomes unused.
+    cfg = store.load_gui_config()
+    cfg.sync_groups = []
+    store.save_gui_config(cfg)
+
     tab = ConfigTab(store)
     qtbot.addWidget(tab)
     monkeypatch.setattr(
-        QMessageBox,
-        "question",
-        lambda *a, **k: QMessageBox.StandardButton.Yes,
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
     )
-    tab._conn_list.setCurrentRow(0)  # garmin
+    tab._conn_list.setCurrentRow(1)  # local
     tab._delete_connector()
 
-    reloaded = store.load_gui_config()
-    assert [c.id for c in reloaded.connectors] == ["local"]
-    assert reloaded.sync_groups[0].sources == []
-    assert reloaded.sync_groups[0].destinations == ["local"]
+    assert [c.id for c in store.load_gui_config().connectors] == ["garmin"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-import os
+from datetime import date
 from pathlib import Path
 
 import pytest
-
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-from datetime import date
-
 from PySide6.QtCore import Qt
 
 from app.gui.app import (

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -196,6 +196,28 @@ def test_sync_group_dialog_prefilled(qtbot) -> None:
     assert entry.destinations == ["local"]
 
 
+def test_sync_group_dialog_ignores_duplicate_source(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin", "strava"])
+    qtbot.addWidget(dlg)
+    dlg._src_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert [s.id for s in entry.sources] == ["garmin"]
+
+
+def test_sync_group_dialog_ignores_duplicate_destination(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin", "strava"])
+    qtbot.addWidget(dlg)
+    dlg._dst_add_combo.setCurrentText("strava")
+    qtbot.mouseClick(dlg._dst_add_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(dlg._dst_add_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert entry.destinations == ["strava"]
+
+
 def test_sync_group_dialog_source_id_with_colon(qtbot) -> None:
     # Connector ids may contain a colon; the source must round-trip intact.
     existing = SyncGroupEntry(

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -113,6 +113,15 @@ def test_connector_dialog_garmin_default(qtbot) -> None:
     assert entry.id == ""
 
 
+def test_connector_dialog_type_dropdown_matches_supported_types(qtbot) -> None:
+    from app.gui.config_store import CONNECTOR_TYPES
+
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    items = [dlg._type.itemText(i) for i in range(dlg._type.count())]
+    assert items == list(CONNECTOR_TYPES)
+
+
 def test_connector_dialog_prefilled_strava(qtbot) -> None:
     existing = ConnectorEntry(
         id="strava",

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -201,6 +201,27 @@ def test_connector_dialog_selecting_service_autofills_account(qtbot) -> None:
     assert entry.credential_login == "me@x"
 
 
+def test_connector_dialog_url_follows_selected_service(qtbot) -> None:
+    # The URL belongs to the account, so it must track the chosen service and
+    # never be an independent choice that could mismatch it.
+    from PySide6.QtWidgets import QLineEdit
+
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "g@x", "p"),
+        CredentialEntry("Strava", "https://www.strava.com/api/v3", "cs", "rt"),
+    ]
+    dlg = ConnectorDialog(credentials=creds)
+    qtbot.addWidget(dlg)
+    # URL is a derived read-only field, not a cross-service dropdown.
+    assert isinstance(dlg._cred_url, QLineEdit)
+    assert dlg._cred_url.isReadOnly()
+
+    dlg._cred_service.setCurrentText("Strava")
+    assert dlg.result_entry().credential_url == "https://www.strava.com/api/v3"
+    dlg._cred_service.setCurrentText("Garmin Connect")
+    assert dlg.result_entry().credential_url == "https://connect.garmin.com"
+
+
 def test_connector_dialog_prefilled_credentials_not_clobbered(qtbot) -> None:
     # Opening an existing connector must keep its stored URL/login even when a
     # matching service exists in the credentials list.

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -213,6 +213,22 @@ def test_connector_dialog_local_folder(qtbot) -> None:
     assert entry.folder == "/data"
 
 
+def test_connector_dialog_local_folder_carries_no_credential(qtbot) -> None:
+    # Even with credentials configured (and auto-selected in the combo), a
+    # local_folder connector must not reference any credential.
+    creds = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p")
+    ]
+    dlg = ConnectorDialog(credentials=creds)
+    qtbot.addWidget(dlg)
+    dlg._type.setCurrentText("local_folder")
+    dlg._folder.setText("/data")
+    entry = dlg.result_entry()
+    assert entry.credential_service == ""
+    assert entry.credential_url == ""
+    assert entry.credential_login == ""
+
+
 def test_connector_dialog_type_change_hides_cred_box(qtbot) -> None:
     dlg = ConnectorDialog()
     qtbot.addWidget(dlg)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -105,6 +105,16 @@ def test_credential_dialog_defaults_to_manual_source(qtbot) -> None:
     assert dlg._keepass_row.isHidden()
 
 
+def test_credential_dialog_service_field_labeled_account_name(qtbot) -> None:
+    from PySide6.QtWidgets import QLabel
+
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    labels = [w.text() for w in dlg.findChildren(QLabel)]
+    assert "Account name:" in labels
+    assert "Service:" not in labels
+
+
 def test_credential_dialog_url_dropdown_presets_and_free_text(qtbot) -> None:
     dlg = CredentialDialog()
     qtbot.addWidget(dlg)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -42,6 +42,21 @@ def store(tmp_path: Path) -> ConfigStore:
     return ConfigStore(config_dir=tmp_path / "cfg")
 
 
+class _RejectingDialog:
+    """Records the entry it was opened with, then cancels (no changes)."""
+
+    def __init__(self, opened: dict, entry: object) -> None:
+        opened["entry"] = entry
+
+    def exec(self) -> int:
+        from PySide6.QtWidgets import QDialog
+
+        return QDialog.DialogCode.Rejected
+
+    def result_entry(self) -> object:  # pragma: no cover - never called on reject
+        raise AssertionError("result_entry must not be read after cancel")
+
+
 # ---------------------------------------------------------------------------
 # _parse_date_or_default
 # ---------------------------------------------------------------------------
@@ -540,6 +555,25 @@ def test_credentials_tab_edit_no_selection_does_nothing(
     tab._table.clearSelection()
     # Should not raise
     tab._edit()
+
+
+def test_credentials_tab_double_click_opens_edit(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    store.save_credentials([CredentialEntry("Acc", "u", "l", "p")])
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    opened: dict = {}
+    monkeypatch.setattr(
+        gui_app,
+        "CredentialDialog",
+        lambda **kw: _RejectingDialog(opened, kw.get("entry")),
+    )
+    tab._table.selectRow(0)
+    tab._table.itemDoubleClicked.emit(tab._table.item(0, 0))
+    assert opened["entry"].service == "Acc"
 
 
 class _FakeCredentialDialog:
@@ -1041,6 +1075,55 @@ def test_config_tab_add_group_rejects_duplicate_name(
 
     assert warned == [True]
     assert [g.id for g in store.load_gui_config().sync_groups] == ["g"]
+
+
+def test_config_tab_double_click_connector_opens_edit(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(connectors=[ConnectorEntry(id="garmin", type="local_folder")])
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    opened: dict = {}
+    monkeypatch.setattr(
+        gui_app,
+        "ConnectorDialog",
+        lambda **kw: _RejectingDialog(opened, kw.get("entry")),
+    )
+    tab._conn_list.setCurrentRow(0)
+    tab._conn_list.itemDoubleClicked.emit(tab._conn_list.item(0))
+    assert opened["entry"].id == "garmin"
+
+
+def test_config_tab_double_click_group_opens_edit(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[ConnectorEntry(id="local", type="local_folder", folder="/x")],
+            sync_groups=[
+                SyncGroupEntry(
+                    id="g", sources=[GroupSourceEntry("local", 1)], destinations=[]
+                )
+            ],
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+    opened: dict = {}
+    monkeypatch.setattr(
+        gui_app,
+        "SyncGroupDialog",
+        lambda **kw: _RejectingDialog(opened, kw.get("entry")),
+    )
+    tab._grp_list.setCurrentRow(0)
+    tab._grp_list.itemDoubleClicked.emit(tab._grp_list.item(0))
+    assert opened["entry"].id == "g"
 
 
 def test_config_tab_delete_connector_used_in_group_is_blocked(

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -478,6 +478,86 @@ def test_credentials_tab_edit_no_selection_does_nothing(
     tab._edit()
 
 
+class _FakeCredentialDialog:
+    def __init__(self, entry: CredentialEntry) -> None:
+        self._entry = entry
+
+    def exec(self) -> int:
+        from PySide6.QtWidgets import QDialog
+
+        return QDialog.DialogCode.Accepted
+
+    def result_entry(self) -> CredentialEntry:
+        return self._entry
+
+
+def _store_with_connector_using_garmin(store: ConfigStore) -> None:
+    store.save_credentials(
+        [CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p")]
+    )
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(
+                    id="garmin",
+                    type="garmin",
+                    credential_service="Garmin Connect",
+                    credential_url="https://connect.garmin.com",
+                    credential_login="me@x",
+                )
+            ]
+        )
+    )
+
+
+def test_credentials_tab_edit_identity_of_used_credential_is_blocked(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    import app.gui.app as gui_app
+
+    _store_with_connector_using_garmin(store)
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+
+    renamed = CredentialEntry(
+        "Garmin Connect", "https://connect.garmin.com", "new@x", "p"
+    )
+    monkeypatch.setattr(
+        gui_app, "CredentialDialog", lambda **kw: _FakeCredentialDialog(renamed)
+    )
+    warned: list[bool] = []
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: warned.append(True))
+    tab._table.selectRow(0)
+    tab._edit()
+
+    assert warned == [True]
+    assert store.load_credentials()[0].login == "me@x"  # unchanged
+
+
+def test_credentials_tab_edit_password_of_used_credential_is_allowed(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    _store_with_connector_using_garmin(store)
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+
+    # Same identity, new password - must be allowed even while referenced.
+    updated = CredentialEntry(
+        "Garmin Connect", "https://connect.garmin.com", "me@x", "new-pw"
+    )
+    monkeypatch.setattr(
+        gui_app, "CredentialDialog", lambda **kw: _FakeCredentialDialog(updated)
+    )
+    tab._table.selectRow(0)
+    tab._edit()
+
+    assert store.load_credentials()[0].password == "new-pw"
+
+
 def test_credentials_tab_delete_credential_used_by_connector_is_blocked(
     qtbot, monkeypatch, store: ConfigStore
 ) -> None:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -424,6 +424,58 @@ def test_credentials_tab_edit_no_selection_does_nothing(
     tab._edit()
 
 
+def test_credentials_tab_delete_credential_used_by_connector_is_blocked(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    store.save_credentials(
+        [CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "p")]
+    )
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(
+                    id="garmin",
+                    type="garmin",
+                    credential_service="Garmin Connect",
+                    credential_url="https://connect.garmin.com",
+                    credential_login="me@x",
+                )
+            ]
+        )
+    )
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    warned: dict[str, str] = {}
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda _s, title, text, *a, **k: warned.update(t=text)
+    )
+    tab._table.selectRow(0)
+    tab._delete()
+
+    # The credential is kept and the warning names the offending connector.
+    assert tab._table.rowCount() == 1
+    assert "'garmin'" in warned["t"]
+
+
+def test_credentials_tab_delete_unused_credential_succeeds(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    store.save_credentials([CredentialEntry("Lonely", "u", "l", "p")])
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes
+    )
+    tab._table.selectRow(0)
+    tab._delete()
+
+    assert tab._table.rowCount() == 0
+
+
 def test_credentials_tab_masks_password(qtbot, store: ConfigStore) -> None:
     store.save_credentials([CredentialEntry("S", "U", "L", "supersecret")])
     tab = CredentialsTab(store)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -1,0 +1,340 @@
+"""Behavioural tests for the GUI widgets using pytest-qt."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from datetime import date
+
+from PySide6.QtCore import Qt
+
+from app.gui.app import (
+    ConnectorDialog,
+    CredentialDialog,
+    CredentialsTab,
+    LogDialog,
+    MainWindow,
+    SyncGroupDialog,
+    TaskRow,
+    _parse_date_or_default,
+)
+from app.gui.config_store import (
+    ConfigStore,
+    ConnectorEntry,
+    CredentialEntry,
+    GroupSourceEntry,
+    SyncGroupEntry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> ConfigStore:
+    return ConfigStore(config_dir=tmp_path / "cfg")
+
+
+# ---------------------------------------------------------------------------
+# _parse_date_or_default
+# ---------------------------------------------------------------------------
+
+
+def test_parse_date_or_default_empty() -> None:
+    assert _parse_date_or_default("", date(2000, 1, 1)) == date(2000, 1, 1)
+
+
+def test_parse_date_or_default_value() -> None:
+    assert _parse_date_or_default("2025-06-15", date(2000, 1, 1)) == date(2025, 6, 15)
+
+
+# ---------------------------------------------------------------------------
+# CredentialDialog
+# ---------------------------------------------------------------------------
+
+
+def test_credential_dialog_empty(qtbot) -> None:
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.service == ""
+    assert entry.login == ""
+
+
+def test_credential_dialog_prefilled(qtbot) -> None:
+    existing = CredentialEntry(
+        "Garmin Connect", "https://connect.garmin.com", "user", "pass"
+    )
+    dlg = CredentialDialog(entry=existing)
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.service == "Garmin Connect"
+    assert entry.login == "user"
+    assert entry.password == "pass"
+
+
+def test_credential_dialog_password_echo_hidden(qtbot) -> None:
+    from PySide6.QtWidgets import QLineEdit
+
+    dlg = CredentialDialog()
+    qtbot.addWidget(dlg)
+    # The last QLineEdit in the dialog is the password field.
+    fields = dlg.findChildren(QLineEdit)
+    pw = fields[-1]
+    assert pw.echoMode() == QLineEdit.EchoMode.Password
+
+
+# ---------------------------------------------------------------------------
+# ConnectorDialog
+# ---------------------------------------------------------------------------
+
+
+def test_connector_dialog_garmin_default(qtbot) -> None:
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.type == "garmin"
+    assert entry.id == ""
+
+
+def test_connector_dialog_prefilled_strava(qtbot) -> None:
+    existing = ConnectorEntry(
+        id="strava",
+        type="strava",
+        credential_service="Strava",
+        credential_url="https://www.strava.com/api/v3",
+        client_id=12345,
+    )
+    dlg = ConnectorDialog(entry=existing)
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.type == "strava"
+    assert entry.client_id == 12345
+
+
+def test_connector_dialog_local_folder(qtbot) -> None:
+    existing = ConnectorEntry(id="local", type="local_folder", folder="/data")
+    dlg = ConnectorDialog(entry=existing)
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.type == "local_folder"
+    assert entry.folder == "/data"
+
+
+def test_connector_dialog_type_change_hides_cred_box(qtbot) -> None:
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    dlg._type.setCurrentText("local_folder")
+    # isHidden() reflects the explicit hidden flag regardless of parent visibility.
+    assert dlg._cred_box.isHidden()
+    assert not dlg._folder_box.isHidden()
+
+
+def test_connector_dialog_type_change_shows_strava_client_id(qtbot) -> None:
+    dlg = ConnectorDialog()
+    qtbot.addWidget(dlg)
+    dlg._type.setCurrentText("strava")
+    assert not dlg._client_id_spin.isHidden()
+
+
+# ---------------------------------------------------------------------------
+# SyncGroupDialog
+# ---------------------------------------------------------------------------
+
+
+def test_sync_group_dialog_add_source_and_destination(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin", "strava"])
+    qtbot.addWidget(dlg)
+    dlg._id.setText("test-group")
+
+    dlg._src_add_combo.setCurrentText("garmin")
+    dlg._src_priority.setValue(2)
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
+
+    dlg._dst_add_combo.setCurrentText("strava")
+    qtbot.mouseClick(dlg._dst_add_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert entry.id == "test-group"
+    assert len(entry.sources) == 1
+    assert entry.sources[0].id == "garmin"
+    assert entry.sources[0].priority == 2
+    assert entry.destinations == ["strava"]
+
+
+def test_sync_group_dialog_remove_source(qtbot) -> None:
+    existing = SyncGroupEntry(
+        id="g",
+        sources=[GroupSourceEntry("s1", 1), GroupSourceEntry("s2", 2)],
+        destinations=[],
+    )
+    dlg = SyncGroupDialog(connector_ids=["s1", "s2"], entry=existing)
+    qtbot.addWidget(dlg)
+    dlg._sources_widget.setCurrentRow(0)
+    qtbot.mouseClick(dlg._src_del_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert len(entry.sources) == 1
+    assert entry.sources[0].id == "s2"
+
+
+def test_sync_group_dialog_prefilled(qtbot) -> None:
+    existing = SyncGroupEntry(
+        id="grp",
+        sources=[GroupSourceEntry("garmin", 1)],
+        destinations=["local"],
+    )
+    dlg = SyncGroupDialog(connector_ids=["garmin", "local"], entry=existing)
+    qtbot.addWidget(dlg)
+    entry = dlg.result_entry()
+    assert entry.id == "grp"
+    assert entry.destinations == ["local"]
+
+
+# ---------------------------------------------------------------------------
+# CredentialsTab
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_tab_shows_stored_entries(qtbot, store: ConfigStore) -> None:
+    store.save_credentials(
+        [CredentialEntry("Garmin Connect", "https://connect.garmin.com", "u", "p")]
+    )
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    assert tab._table.rowCount() == 1
+    assert tab._table.item(0, 0).text() == "Garmin Connect"
+
+
+def test_credentials_tab_delete_no_selection_does_nothing(
+    qtbot, store: ConfigStore
+) -> None:
+    store.save_credentials([CredentialEntry("S", "U", "L", "P")])
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    tab._table.clearSelection()
+    tab._delete()
+    assert tab._table.rowCount() == 1
+
+
+def test_credentials_tab_edit_no_selection_does_nothing(
+    qtbot, store: ConfigStore
+) -> None:
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    tab._table.clearSelection()
+    # Should not raise
+    tab._edit()
+
+
+def test_credentials_tab_masks_password(qtbot, store: ConfigStore) -> None:
+    store.save_credentials([CredentialEntry("S", "U", "L", "supersecret")])
+    tab = CredentialsTab(store)
+    qtbot.addWidget(tab)
+    displayed = tab._table.item(0, 3).text()
+    assert "supersecret" not in displayed
+
+
+# ---------------------------------------------------------------------------
+# TaskRow
+# ---------------------------------------------------------------------------
+
+
+def test_task_row_progress_with_total(qtbot) -> None:
+    row = TaskRow("Download", total=10)
+    qtbot.addWidget(row)
+    row.update_progress(5)
+    assert row._bar.value() == 5
+    assert "5/10" in row._count.text()
+
+
+def test_task_row_progress_no_total(qtbot) -> None:
+    row = TaskRow("Login", total=None)
+    qtbot.addWidget(row)
+    row.update_progress(3)
+    assert row._count.text() == "3"
+
+
+def test_task_row_mark_done_no_warnings(qtbot) -> None:
+    row = TaskRow("Task", total=5)
+    qtbot.addWidget(row)
+    row.mark_done([])
+    assert "[OK]" in row._status.text()
+    assert row._bar.value() == row._bar.maximum()
+
+
+def test_task_row_mark_done_with_warnings(qtbot) -> None:
+    row = TaskRow("Task", total=5)
+    qtbot.addWidget(row)
+    row.mark_done(["warn1"])
+    assert "[!]" in row._status.text()
+    assert "1 warning" in row._label.text()
+
+
+def test_task_row_mark_failed(qtbot) -> None:
+    row = TaskRow("Task", total=5)
+    qtbot.addWidget(row)
+    row.mark_failed("connection refused")
+    assert "[X]" in row._status.text()
+    assert "connection refused" in row._label.text()
+
+
+def test_task_row_update_total(qtbot) -> None:
+    row = TaskRow("Task", total=None)
+    qtbot.addWidget(row)
+    row.update_total(20)
+    assert row._total == 20
+    assert row._bar.maximum() == 20
+
+
+# ---------------------------------------------------------------------------
+# LogDialog
+# ---------------------------------------------------------------------------
+
+
+def test_log_dialog_missing_file(qtbot, tmp_path: Path) -> None:
+    from PySide6.QtWidgets import QTextEdit
+
+    dlg = LogDialog(log_path=tmp_path / "missing.log")
+    qtbot.addWidget(dlg)
+    texts = dlg.findChildren(QTextEdit)
+    assert any("not found" in w.toPlainText() for w in texts)
+
+
+def test_log_dialog_existing_file(qtbot, tmp_path: Path) -> None:
+    log = tmp_path / "sync.log"
+    log.write_text("line1\nline2\n", encoding="utf-8")
+    dlg = LogDialog(log_path=log)
+    qtbot.addWidget(dlg)
+    from PySide6.QtWidgets import QTextEdit
+
+    texts = dlg.findChildren(QTextEdit)
+    assert any("line1" in w.toPlainText() for w in texts)
+
+
+# ---------------------------------------------------------------------------
+# MainWindow
+# ---------------------------------------------------------------------------
+
+
+def test_main_window_has_three_tabs(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tabs = window.centralWidget()
+    assert tabs.count() == 3
+
+
+def test_main_window_tab_labels(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tabs = window.centralWidget()
+    labels = [tabs.tabText(i) for i in range(tabs.count())]
+    assert "Credentials" in labels
+    assert "Configuration" in labels
+    assert "Sync" in labels

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -401,6 +401,33 @@ def test_sync_group_dialog_ignores_duplicate_destination(qtbot) -> None:
     assert entry.destinations == ["strava"]
 
 
+def test_sync_group_dialog_source_cannot_also_be_destination(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin", "strava"])
+    qtbot.addWidget(dlg)
+    dlg._src_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
+    # Adding the same connector as a destination is refused.
+    dlg._dst_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._dst_add_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert [s.id for s in entry.sources] == ["garmin"]
+    assert entry.destinations == []
+
+
+def test_sync_group_dialog_destination_cannot_also_be_source(qtbot) -> None:
+    dlg = SyncGroupDialog(connector_ids=["garmin", "strava"])
+    qtbot.addWidget(dlg)
+    dlg._dst_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._dst_add_btn, Qt.MouseButton.LeftButton)
+    dlg._src_add_combo.setCurrentText("garmin")
+    qtbot.mouseClick(dlg._src_add_btn, Qt.MouseButton.LeftButton)
+
+    entry = dlg.result_entry()
+    assert entry.destinations == ["garmin"]
+    assert entry.sources == []
+
+
 def test_sync_group_dialog_source_id_with_colon(qtbot) -> None:
     # Connector ids may contain a colon; the source must round-trip intact.
     existing = SyncGroupEntry(

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -17,6 +17,7 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
+    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -126,6 +127,33 @@ def test_load_credentials_from_rejects_non_array(
     src.write_text(json.dumps({"service": "x"}), encoding="utf-8")
     with pytest.raises(ValueError, match="must contain a JSON array"):
         store.load_credentials_from(src)
+
+
+# ---------------------------------------------------------------------------
+# Credential source
+# ---------------------------------------------------------------------------
+
+
+def test_credential_source_defaults_to_json(store: ConfigStore) -> None:
+    cs = store.load_credential_source()
+    assert cs.source == "json"
+    assert cs.keepass_path == ""
+
+
+def test_save_and_load_credential_source(store: ConfigStore) -> None:
+    store.save_credential_source(
+        CredentialSource(source="keepass", keepass_path="/home/me/db.kdbx")
+    )
+    cs = store.load_credential_source()
+    assert cs.source == "keepass"
+    assert cs.keepass_path == "/home/me/db.kdbx"
+
+
+def test_credential_source_is_separate_from_gui_config(store: ConfigStore) -> None:
+    # Saving the GUI config must not clobber the credential-source file.
+    store.save_credential_source(CredentialSource(source="keepass", keepass_path="/x"))
+    store.save_gui_config(GuiConfig())
+    assert store.load_credential_source().source == "keepass"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -28,6 +28,7 @@ from app.gui.config_store import (
     _parse_connector_entry,
     _parse_group_entry,
     _serialize_connector,
+    _serialize_credential,
     _serialize_group,
 )
 
@@ -94,6 +95,58 @@ def test_save_credentials_overwrites(store: ConfigStore) -> None:
     loaded = store.load_credentials()
     assert len(loaded) == 1
     assert loaded[0].service == "B"
+
+
+def test_manual_credential_defaults_to_manual_source(store: ConfigStore) -> None:
+    store.save_credentials([CredentialEntry("S", "U", "L", "P")])
+    loaded = store.load_credentials()[0]
+    assert loaded.source == "manual"
+    assert loaded.password == "P"
+    assert loaded.keepass_path == ""
+
+
+def test_keepass_credential_round_trips_without_password(store: ConfigStore) -> None:
+    entry = CredentialEntry(
+        "Garmin Connect",
+        "https://connect.garmin.com",
+        "me@x",
+        source="keepass",
+        keepass_path="/home/me/db.kdbx",
+    )
+    store.save_credentials([entry])
+    loaded = store.load_credentials()[0]
+    assert loaded == entry
+    assert loaded.password == ""
+
+
+def test_serialize_credential_manual_has_password_no_path() -> None:
+    d = _serialize_credential(CredentialEntry("S", "U", "L", "secret"))
+    assert d["source"] == "manual"
+    assert d["password"] == "secret"
+    assert "keepass_path" not in d
+
+
+def test_serialize_credential_keepass_has_path_no_password() -> None:
+    d = _serialize_credential(
+        CredentialEntry("S", "U", "L", source="keepass", keepass_path="/x.kdbx")
+    )
+    assert d["source"] == "keepass"
+    assert d["keepass_path"] == "/x.kdbx"
+    assert "password" not in d
+
+
+def test_legacy_credential_without_source_parses_as_manual(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    # A CLI creds.json has no "source" field.
+    src = tmp_path / "creds.json"
+    src.write_text(
+        json.dumps([{"service": "S", "url": "U", "login": "L", "password": "P"}]),
+        encoding="utf-8",
+    )
+    loaded = store.load_credentials_from(src)[0]
+    assert loaded.source == "manual"
+    assert loaded.password == "P"
 
 
 def test_load_credentials_from_arbitrary_path(

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -94,6 +94,40 @@ def test_save_credentials_overwrites(store: ConfigStore) -> None:
     assert loaded[0].service == "B"
 
 
+def test_load_credentials_from_arbitrary_path(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    src = tmp_path / "creds.json"
+    src.write_text(
+        json.dumps(
+            [
+                {
+                    "service": "Garmin Connect",
+                    "url": "https://connect.garmin.com",
+                    "login": "me@example.com",
+                    "password": "s3cr3t",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    loaded = store.load_credentials_from(src)
+    assert loaded == [
+        CredentialEntry(
+            "Garmin Connect", "https://connect.garmin.com", "me@example.com", "s3cr3t"
+        )
+    ]
+
+
+def test_load_credentials_from_rejects_non_array(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    src = tmp_path / "creds.json"
+    src.write_text(json.dumps({"service": "x"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must contain a JSON array"):
+        store.load_credentials_from(src)
+
+
 # ---------------------------------------------------------------------------
 # GuiConfig - load / save
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -1,0 +1,417 @@
+"""Tests for app.gui.config_store."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app.core.config import (
+    GarminConnectorConfig,
+    LocalFolderConnectorConfig,
+    StravaConnectorConfig,
+)
+from app.gui.config_store import (
+    ConfigStore,
+    ConnectorEntry,
+    CredentialEntry,
+    GroupSourceEntry,
+    GuiConfig,
+    SyncGroupEntry,
+    _atomic_write,
+    _connector_to_app,
+    _group_to_app,
+    _parse_connector_entry,
+    _parse_group_entry,
+    _serialize_connector,
+    _serialize_group,
+)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> ConfigStore:
+    return ConfigStore(config_dir=tmp_path / "cfg")
+
+
+# ---------------------------------------------------------------------------
+# ConfigStore - directory creation
+# ---------------------------------------------------------------------------
+
+
+def test_store_creates_directory(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / "a" / "b" / "c"
+    assert not cfg_dir.exists()
+    store = ConfigStore(config_dir=cfg_dir)
+    assert store.config_dir.exists()
+
+
+def test_cache_dir_property(store: ConfigStore) -> None:
+    assert store.cache_dir == store.config_dir / "cache"
+
+
+def test_credentials_path_property(store: ConfigStore) -> None:
+    assert store.credentials_path == store.config_dir / "credentials.json"
+
+
+# ---------------------------------------------------------------------------
+# Credentials - load / save
+# ---------------------------------------------------------------------------
+
+
+def test_load_credentials_empty_when_file_absent(store: ConfigStore) -> None:
+    assert store.load_credentials() == []
+
+
+def test_save_and_load_credentials(store: ConfigStore) -> None:
+    entries = [
+        CredentialEntry(
+            "Garmin Connect", "https://connect.garmin.com", "me@example.com", "s3cr3t"
+        ),
+        CredentialEntry(
+            "Strava", "https://www.strava.com/api/v3", "clientsecret", "refreshtoken"
+        ),
+    ]
+    store.save_credentials(entries)
+    loaded = store.load_credentials()
+    assert loaded == entries
+
+
+def test_save_credentials_uses_atomic_write(store: ConfigStore) -> None:
+    # After saving, no .tmp file should remain.
+    store.save_credentials([CredentialEntry("S", "U", "L", "P")])
+    tmp = store.credentials_path.with_suffix(".tmp")
+    assert not tmp.exists()
+    assert store.credentials_path.exists()
+
+
+def test_save_credentials_overwrites(store: ConfigStore) -> None:
+    store.save_credentials([CredentialEntry("A", "U1", "L1", "P1")])
+    store.save_credentials([CredentialEntry("B", "U2", "L2", "P2")])
+    loaded = store.load_credentials()
+    assert len(loaded) == 1
+    assert loaded[0].service == "B"
+
+
+# ---------------------------------------------------------------------------
+# GuiConfig - load / save
+# ---------------------------------------------------------------------------
+
+
+def test_load_gui_config_defaults_when_absent(store: ConfigStore) -> None:
+    cfg = store.load_gui_config()
+    assert cfg.connectors == []
+    assert cfg.sync_groups == []
+    assert cfg.start == ""
+    assert cfg.end == ""
+    assert cfg.force is False
+    assert cfg.skip_wellness is False
+
+
+def test_save_and_load_gui_config_round_trips(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[
+            ConnectorEntry(
+                id="garmin",
+                type="garmin",
+                credential_service="Garmin Connect",
+                credential_url="https://connect.garmin.com",
+                credential_login="me@example.com",
+            ),
+            ConnectorEntry(
+                id="strava",
+                type="strava",
+                credential_service="Strava",
+                credential_url="https://www.strava.com/api/v3",
+                client_id=12345,
+            ),
+            ConnectorEntry(id="local", type="local_folder", folder="/tmp/activities"),
+        ],
+        sync_groups=[
+            SyncGroupEntry(
+                id="s-to-g",
+                sources=[GroupSourceEntry(id="strava", priority=1)],
+                destinations=["garmin"],
+            ),
+        ],
+        start="2025-01-01",
+        end="2025-12-31",
+        force=True,
+        skip_wellness=True,
+    )
+    store.save_gui_config(cfg)
+    loaded = store.load_gui_config()
+
+    assert loaded.start == "2025-01-01"
+    assert loaded.end == "2025-12-31"
+    assert loaded.force is True
+    assert loaded.skip_wellness is True
+    assert len(loaded.connectors) == 3
+    assert loaded.connectors[0].id == "garmin"
+    assert loaded.connectors[1].client_id == 12345
+    assert loaded.connectors[2].folder == "/tmp/activities"
+    assert len(loaded.sync_groups) == 1
+    sg = loaded.sync_groups[0]
+    assert sg.id == "s-to-g"
+    assert sg.sources[0].id == "strava"
+    assert sg.sources[0].priority == 1
+    assert sg.destinations == ["garmin"]
+
+
+def test_save_gui_config_omits_empty_dates(store: ConfigStore) -> None:
+    store.save_gui_config(GuiConfig())
+    raw = json.loads((store.config_dir / "config.json").read_text())
+    assert "start" not in raw
+    assert "end" not in raw
+
+
+def test_save_gui_config_includes_nonempty_dates(store: ConfigStore) -> None:
+    store.save_gui_config(GuiConfig(start="2026-01-01", end="2026-06-30"))
+    raw = json.loads((store.config_dir / "config.json").read_text())
+    assert raw["start"] == "2026-01-01"
+    assert raw["end"] == "2026-06-30"
+
+
+# ---------------------------------------------------------------------------
+# to_app_config conversion
+# ---------------------------------------------------------------------------
+
+
+def test_to_app_config_garmin_connector(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[
+            ConnectorEntry(
+                id="g",
+                type="garmin",
+                credential_service="Garmin Connect",
+                credential_url="https://connect.garmin.com",
+                credential_login="user@example.com",
+            )
+        ],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="g", priority=1)],
+                destinations=[],
+            )
+        ],
+    )
+    app_cfg = store.to_app_config(cfg)
+    assert len(app_cfg.connectors) == 1
+    garmin = app_cfg.connectors[0]
+    assert isinstance(garmin, GarminConnectorConfig)
+    assert garmin.id == "g"
+    assert garmin.credential.login == "user@example.com"
+
+
+def test_to_app_config_strava_connector(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[
+            ConnectorEntry(
+                id="s",
+                type="strava",
+                credential_service="Strava",
+                credential_url="https://www.strava.com/api/v3",
+                client_id=99,
+            )
+        ],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="s", priority=1)],
+                destinations=[],
+            )
+        ],
+    )
+    app_cfg = store.to_app_config(cfg)
+    strava = app_cfg.connectors[0]
+    assert isinstance(strava, StravaConnectorConfig)
+    assert strava.client_id == 99
+
+
+def test_to_app_config_local_connector(store: ConfigStore, tmp_path: Path) -> None:
+    folder = str(tmp_path)
+    cfg = GuiConfig(
+        connectors=[ConnectorEntry(id="l", type="local_folder", folder=folder)],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="l", priority=1)],
+                destinations=[],
+            )
+        ],
+    )
+    app_cfg = store.to_app_config(cfg)
+    local = app_cfg.connectors[0]
+    assert isinstance(local, LocalFolderConnectorConfig)
+    assert local.folder == Path(folder).resolve()
+
+
+def test_to_app_config_date_parsing(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[ConnectorEntry(id="l", type="local_folder", folder="/tmp")],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="l", priority=1)],
+                destinations=[],
+            )
+        ],
+        start="2025-03-01",
+        end="2025-09-30",
+    )
+    app_cfg = store.to_app_config(cfg)
+    assert app_cfg.start == date(2025, 3, 1)
+    assert app_cfg.end == date(2025, 9, 30)
+
+
+def test_to_app_config_empty_dates_are_none(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[ConnectorEntry(id="l", type="local_folder", folder="/tmp")],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="l", priority=1)],
+                destinations=[],
+            )
+        ],
+    )
+    app_cfg = store.to_app_config(cfg)
+    assert app_cfg.start is None
+    assert app_cfg.end is None
+
+
+def test_to_app_config_cache_dir_is_inside_config_dir(store: ConfigStore) -> None:
+    cfg = GuiConfig()
+    app_cfg = store.to_app_config(cfg)
+    assert app_cfg.cache_dir == store.cache_dir
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    _atomic_write(path, {"key": "value"})
+    assert path.exists()
+    assert not path.with_suffix(".tmp").exists()
+    assert json.loads(path.read_text())["key"] == "value"
+
+
+def test_parse_connector_entry_garmin() -> None:
+    raw = {
+        "id": "g",
+        "type": "garmin",
+        "credential_service": "Garmin Connect",
+        "credential_url": "https://connect.garmin.com",
+        "credential_login": "me@example.com",
+    }
+    e = _parse_connector_entry(raw)
+    assert e.id == "g"
+    assert e.type == "garmin"
+    assert e.credential_login == "me@example.com"
+
+
+def test_parse_connector_entry_defaults_missing_keys() -> None:
+    e = _parse_connector_entry({"id": "x", "type": "garmin"})
+    assert e.credential_service == ""
+    assert e.credential_url == ""
+    assert e.credential_login == ""
+    assert e.client_id == 0
+    assert e.folder == ""
+
+
+def test_parse_group_entry() -> None:
+    raw = {
+        "id": "g1",
+        "sources": [{"id": "s", "priority": 2}],
+        "destinations": ["d1", "d2"],
+    }
+    e = _parse_group_entry(raw)
+    assert e.id == "g1"
+    assert e.sources[0].priority == 2
+    assert e.destinations == ["d1", "d2"]
+
+
+def test_serialize_connector_garmin() -> None:
+    c = ConnectorEntry(
+        id="g",
+        type="garmin",
+        credential_service="Garmin Connect",
+        credential_url="https://connect.garmin.com",
+        credential_login="me@example.com",
+    )
+    d = _serialize_connector(c)
+    assert d == {
+        "id": "g",
+        "type": "garmin",
+        "credential_service": "Garmin Connect",
+        "credential_url": "https://connect.garmin.com",
+        "credential_login": "me@example.com",
+    }
+
+
+def test_serialize_connector_garmin_omits_empty_login() -> None:
+    c = ConnectorEntry(
+        id="g",
+        type="garmin",
+        credential_service="Garmin Connect",
+        credential_url="https://connect.garmin.com",
+    )
+    d = _serialize_connector(c)
+    assert "credential_login" not in d
+
+
+def test_serialize_connector_strava() -> None:
+    c = ConnectorEntry(
+        id="s",
+        type="strava",
+        credential_service="Strava",
+        credential_url="https://www.strava.com/api/v3",
+        client_id=12345,
+    )
+    d = _serialize_connector(c)
+    assert d["client_id"] == 12345
+    assert "folder" not in d
+
+
+def test_serialize_connector_local_folder() -> None:
+    c = ConnectorEntry(id="l", type="local_folder", folder="/data")
+    d = _serialize_connector(c)
+    assert d["folder"] == "/data"
+    assert "credential_service" not in d
+
+
+def test_serialize_group() -> None:
+    g = SyncGroupEntry(
+        id="grp",
+        sources=[GroupSourceEntry(id="s", priority=3)],
+        destinations=["d"],
+    )
+    d = _serialize_group(g)
+    assert d == {
+        "id": "grp",
+        "sources": [{"id": "s", "priority": 3}],
+        "destinations": ["d"],
+    }
+
+
+def test_connector_to_app_unknown_type_raises() -> None:
+    c = ConnectorEntry(id="x", type="unknown")
+    with pytest.raises(ValueError, match="unknown connector type"):
+        _connector_to_app(c)
+
+
+def test_group_to_app() -> None:
+    g = SyncGroupEntry(
+        id="grp",
+        sources=[GroupSourceEntry(id="s", priority=1)],
+        destinations=["d"],
+    )
+    sg = _group_to_app(g)
+    assert sg.id == "grp"
+    assert sg.sources[0].id == "s"
+    assert sg.destinations == ("d",)

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -378,6 +378,45 @@ def test_serialize_connector_strava() -> None:
     assert "folder" not in d
 
 
+def test_serialize_connector_strava_with_login() -> None:
+    c = ConnectorEntry(
+        id="s",
+        type="strava",
+        credential_service="Strava",
+        credential_url="https://www.strava.com/api/v3",
+        client_id=12345,
+        credential_login="my_client_secret",
+    )
+    d = _serialize_connector(c)
+    assert d["credential_login"] == "my_client_secret"
+
+
+def test_to_app_config_strava_connector_with_login(store: ConfigStore) -> None:
+    cfg = GuiConfig(
+        connectors=[
+            ConnectorEntry(
+                id="s",
+                type="strava",
+                credential_service="Strava",
+                credential_url="https://www.strava.com/api/v3",
+                client_id=99,
+                credential_login="my_client_secret",
+            )
+        ],
+        sync_groups=[
+            SyncGroupEntry(
+                id="grp",
+                sources=[GroupSourceEntry(id="s", priority=1)],
+                destinations=[],
+            )
+        ],
+    )
+    app_cfg = store.to_app_config(cfg)
+    strava = app_cfg.connectors[0]
+    assert isinstance(strava, StravaConnectorConfig)
+    assert strava.credential.login == "my_client_secret"
+
+
 def test_serialize_connector_local_folder() -> None:
     c = ConnectorEntry(id="l", type="local_folder", folder="/data")
     d = _serialize_connector(c)

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -14,6 +14,7 @@ from app.core.config import (
     StravaConnectorConfig,
 )
 from app.gui.config_store import (
+    CONNECTOR_TYPES,
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
@@ -566,6 +567,21 @@ def test_connector_to_app_unknown_type_raises() -> None:
     c = ConnectorEntry(id="x", type="unknown")
     with pytest.raises(ValueError, match="unknown connector type"):
         _connector_to_app(c)
+
+
+def test_every_connector_type_is_convertible() -> None:
+    # Extensibility guard: every type the GUI offers must be buildable into an
+    # AppConfig connector, so a newly-added type cannot be silently unhandled.
+    for connector_type in CONNECTOR_TYPES:
+        entry = ConnectorEntry(
+            id="x",
+            type=connector_type,
+            credential_service="svc",
+            credential_url="url",
+            folder="/tmp/data",
+        )
+        _connector_to_app(entry)  # must not raise
+        _serialize_connector(entry)  # must not raise
 
 
 def test_group_to_app() -> None:

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -207,6 +207,68 @@ def test_save_gui_config_includes_nonempty_dates(store: ConfigStore) -> None:
     assert raw["end"] == "2026-06-30"
 
 
+def test_load_gui_config_from_arbitrary_path(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    src = tmp_path / "config.json"
+    src.write_text(
+        json.dumps(
+            {
+                "connectors": [
+                    {"id": "local", "type": "local_folder", "folder": "/data"}
+                ],
+                "sync_groups": [
+                    {
+                        "id": "g",
+                        "sources": [{"id": "local", "priority": 1}],
+                        "destinations": [],
+                    }
+                ],
+                "start": "2025-01-01",
+                "force": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = store.load_gui_config_from(src)
+    assert cfg.connectors[0].id == "local"
+    assert cfg.sync_groups[0].id == "g"
+    assert cfg.start == "2025-01-01"
+    assert cfg.force is True
+
+
+def test_load_gui_config_from_ignores_cli_cache_dir(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    # A CLI config file carries a cache_dir field the GUI does not use.
+    src = tmp_path / "cli-config.json"
+    src.write_text(
+        json.dumps(
+            {
+                "cache_dir": "/some/cli/cache",
+                "connectors": [
+                    {"id": "local", "type": "local_folder", "folder": "/data"}
+                ],
+                "sync_groups": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = store.load_gui_config_from(src)
+    assert cfg.connectors[0].id == "local"
+    # The GUI keeps its fixed cache location regardless of the CLI field.
+    assert store.to_app_config(cfg).cache_dir == store.cache_dir
+
+
+def test_load_gui_config_from_rejects_non_object(
+    store: ConfigStore, tmp_path: Path
+) -> None:
+    src = tmp_path / "config.json"
+    src.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        store.load_gui_config_from(src)
+
+
 # ---------------------------------------------------------------------------
 # to_app_config conversion
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -18,7 +18,6 @@ from app.gui.config_store import (
     ConfigStore,
     ConnectorEntry,
     CredentialEntry,
-    CredentialSource,
     GroupSourceEntry,
     GuiConfig,
     SyncGroupEntry,
@@ -181,33 +180,6 @@ def test_load_credentials_from_rejects_non_array(
     src.write_text(json.dumps({"service": "x"}), encoding="utf-8")
     with pytest.raises(ValueError, match="must contain a JSON array"):
         store.load_credentials_from(src)
-
-
-# ---------------------------------------------------------------------------
-# Credential source
-# ---------------------------------------------------------------------------
-
-
-def test_credential_source_defaults_to_json(store: ConfigStore) -> None:
-    cs = store.load_credential_source()
-    assert cs.source == "json"
-    assert cs.keepass_path == ""
-
-
-def test_save_and_load_credential_source(store: ConfigStore) -> None:
-    store.save_credential_source(
-        CredentialSource(source="keepass", keepass_path="/home/me/db.kdbx")
-    )
-    cs = store.load_credential_source()
-    assert cs.source == "keepass"
-    assert cs.keepass_path == "/home/me/db.kdbx"
-
-
-def test_credential_source_is_separate_from_gui_config(store: ConfigStore) -> None:
-    # Saving the GUI config must not clobber the credential-source file.
-    store.save_credential_source(CredentialSource(source="keepass", keepass_path="/x"))
-    store.save_gui_config(GuiConfig())
-    assert store.load_credential_source().source == "keepass"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_credential_provider.py
+++ b/tests/gui/test_credential_provider.py
@@ -1,0 +1,140 @@
+"""Tests for app.gui.credential_provider.GuiCredentialProvider."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.credentials.base import (
+    CredentialRequest,
+    Credentials,
+    CredentialsNotFoundError,
+)
+from app.gui.config_store import CredentialEntry
+from app.gui.credential_provider import GuiCredentialProvider
+from app.tracking.tracker import ProgressRenderer, Task, TaskTracker
+
+
+class _NullRenderer(ProgressRenderer):
+    def on_task_added(self, task: Task) -> None: ...
+    def on_progress(self, task: Task) -> None: ...
+    def on_task_done(self, task: Task) -> None: ...
+    def on_task_failed(self, task: Task) -> None: ...
+    def on_task_warning(self, task: Task, message: str) -> None: ...
+    def on_total_updated(self, task: Task) -> None: ...
+
+
+def _tracker() -> TaskTracker:
+    return TaskTracker(_NullRenderer())
+
+
+def test_manual_credential_returns_inline_password() -> None:
+    entries = [
+        CredentialEntry("Garmin Connect", "https://connect.garmin.com", "me@x", "pw")
+    ]
+    provider = GuiCredentialProvider(entries, {}, _tracker())
+    creds = asyncio.run(
+        provider.get_credentials(
+            CredentialRequest("Garmin Connect", "https://connect.garmin.com", "me@x")
+        )
+    )
+    assert creds == Credentials(login="me@x", password="pw")
+
+
+def test_no_matching_entry_raises() -> None:
+    provider = GuiCredentialProvider([], {}, _tracker())
+    with pytest.raises(CredentialsNotFoundError):
+        asyncio.run(
+            provider.get_credentials(CredentialRequest("Nope", "http://x", None))
+        )
+
+
+def test_keepass_credential_delegates_to_keepass_provider(monkeypatch) -> None:
+    constructed: dict[str, object] = {}
+
+    class _FakeKeePass:
+        def __init__(self, path, password, tracker) -> None:
+            constructed["path"] = str(path)
+            constructed["password"] = password
+
+        async def get_credentials(self, request: CredentialRequest) -> Credentials:
+            return Credentials(login="kp-login", password="kp-secret")
+
+    import app.credentials.keepass as keepass_mod
+
+    monkeypatch.setattr(keepass_mod, "KeePassProvider", _FakeKeePass)
+
+    entries = [
+        CredentialEntry(
+            "Garmin Connect",
+            "https://connect.garmin.com",
+            "me@x",
+            source="keepass",
+            keepass_path="/home/me/db.kdbx",
+        )
+    ]
+    provider = GuiCredentialProvider(
+        entries, {"/home/me/db.kdbx": "master-pw"}, _tracker()
+    )
+    creds = asyncio.run(
+        provider.get_credentials(
+            CredentialRequest("Garmin Connect", "https://connect.garmin.com", "me@x")
+        )
+    )
+    assert creds == Credentials(login="kp-login", password="kp-secret")
+    assert constructed["password"] == "master-pw"
+    assert constructed["path"] == "/home/me/db.kdbx"
+
+
+def test_keepass_provider_is_cached_per_path(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _FakeKeePass:
+        def __init__(self, path, password, tracker) -> None:
+            calls.append(str(path))
+
+        async def get_credentials(self, request: CredentialRequest) -> Credentials:
+            return Credentials(login="l", password="p")
+
+    import app.credentials.keepass as keepass_mod
+
+    monkeypatch.setattr(keepass_mod, "KeePassProvider", _FakeKeePass)
+
+    entries = [
+        CredentialEntry(
+            "A", "http://a", "la", source="keepass", keepass_path="/db.kdbx"
+        ),
+        CredentialEntry(
+            "B", "http://b", "lb", source="keepass", keepass_path="/db.kdbx"
+        ),
+    ]
+    provider = GuiCredentialProvider(entries, {"/db.kdbx": "pw"}, _tracker())
+    asyncio.run(provider.get_credentials(CredentialRequest("A", "http://a", "la")))
+    asyncio.run(provider.get_credentials(CredentialRequest("B", "http://b", "lb")))
+    # Same .kdbx -> the provider (and its opened database) is built only once.
+    assert calls == ["/db.kdbx"]
+
+
+def test_update_refresh_token_updates_manual_and_notifies() -> None:
+    saved: list[list[CredentialEntry]] = []
+    entries = [
+        CredentialEntry("Strava", "https://www.strava.com/api/v3", "cs", "old-token")
+    ]
+    provider = GuiCredentialProvider(
+        entries, {}, _tracker(), on_manual_update=saved.append
+    )
+    provider.update_refresh_token(
+        CredentialRequest("Strava", "https://www.strava.com/api/v3", "cs"),
+        "new-token",
+    )
+    assert entries[0].password == "new-token"
+    assert saved and saved[0][0].password == "new-token"
+
+
+def test_update_refresh_token_unknown_raises() -> None:
+    provider = GuiCredentialProvider([], {}, _tracker())
+    with pytest.raises(CredentialsNotFoundError):
+        provider.update_refresh_token(
+            CredentialRequest("Strava", "http://x", "cs"), "tok"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -793,6 +793,54 @@ wheels = [
 ]
 
 [[package]]
+name = "pyside6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a6/27ba5947ed48918f7b74b7c43a1e280aac069e36f25adeb4c9adfac835c4/pyside6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:537682c3b7530817203e667c1f5a2f00486b37bf52c52eeab438544c7a0917f6", size = 571921, upload-time = "2026-05-13T09:47:36.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2", size = 572102, upload-time = "2026-05-13T09:47:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84", size = 572098, upload-time = "2026-05-13T09:47:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f2/d9d8ce1373dabb37e5919f63cd18446556079631d3f2eea3ada03c29f6b8/pyside6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0968877ab1fb4ef3587a284da6fe05e8647ada56a6a3750b6395188e01f4aba6", size = 578377, upload-time = "2026-05-13T09:47:40.76Z" },
+    { url = "https://files.pythonhosted.org/packages/96/02/a6057d8bd2bdb1940820fff2d627fdf4013148c9c57adf69fa40d3452ac3/pyside6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:acee467cb5f256cc47ebb9d815a054c1d8416da380c191b247a76d164aa3f805", size = 561765, upload-time = "2026-05-13T09:47:41.9Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6b/8bc94aff48b63f788f2d84e5467c12362d68906ba742c0942f46cb04c879/pyside6_addons-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:54733c77f789bef5f03c6aff4ad3bec8b2eff021f0cfcbc53d5e6c250ded24f9", size = 331714589, upload-time = "2026-05-13T09:39:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f", size = 175063224, upload-time = "2026-05-13T09:39:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993", size = 170553429, upload-time = "2026-05-13T09:39:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bd/8adc4d350b3b363f3dfc8fccdcf5bfed25f7e36c2fff30c64e106f4f1572/pyside6_addons-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0d13c4dfd671b050a48e4f8d8ddc724b7248f9c0437e7fc47fdf316278572923", size = 168816308, upload-time = "2026-05-13T09:40:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b7/9a840d97f0f0f04e372a87e205dd30ee285b4e3b021b188459a917c9dc76/pyside6_addons-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:3494f480dee92f415be2f2d989c0b3f4755ac332b28045cbf4ba0f5c5a22ba37", size = 35759347, upload-time = "2026-05-13T09:40:21.199Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -832,6 +880,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
 ]
 
 [[package]]
@@ -973,6 +1035,18 @@ wheels = [
 ]
 
 [[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,6 +1097,7 @@ dependencies = [
     { name = "gpxpy" },
     { name = "idna" },
     { name = "pykeepass" },
+    { name = "pyside6" },
     { name = "python-fitparse" },
     { name = "requests" },
     { name = "rich" },
@@ -1038,6 +1113,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-qt" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -1049,6 +1125,7 @@ requires-dist = [
     { name = "gpxpy", specifier = ">=1.6,<2" },
     { name = "idna", specifier = ">=3.15,<4" },
     { name = "pykeepass", specifier = ">=4.1.1.post1,<5" },
+    { name = "pyside6", specifier = ">=6.7,<7" },
     { name = "python-fitparse", specifier = ">=2.1,<3" },
     { name = "requests", specifier = ">=2.32,<3" },
     { name = "rich", specifier = ">=15.0.0,<16" },
@@ -1059,11 +1136,12 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=4.13.10,<5" },
-    { name = "mypy", specifier = ">=1.20.2,<2" },
+    { name = "mypy", specifier = ">=1.20.2,<3" },
     { name = "pre-commit", specifier = ">=4.6.0,<5" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8" },
+    { name = "pytest-qt", specifier = ">=4.4,<5" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4" },
     { name = "ruff", specifier = ">=0.15.12,<0.16" },
     { name = "types-requests", specifier = ">=2.32,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -359,16 +359,16 @@ wheels = [
 
 [[package]]
 name = "garminconnect"
-version = "0.3.3"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "curl-cffi" },
     { name = "requests" },
     { name = "ua-generator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/d9/7ad240d86453de083f0c460ee328e8209232d9d0ee099dcf49439d90be7a/garminconnect-0.3.3.tar.gz", hash = "sha256:f608193d7a90079fa1fd1d86e8d10e88b871b6ab2500372a9dc48358f8c2d386", size = 52234, upload-time = "2026-04-22T12:57:24.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/29/f8e3609f22693020dec65d6285adf12daac459461a09e59dffe12ec7fc08/garminconnect-0.3.6.tar.gz", hash = "sha256:6f90aa282976f7dff880cf53ef4f3ea0d63701fd2a1488c628a66a2a027c2143", size = 61911, upload-time = "2026-06-14T08:05:37.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/5a/69af564ff61c87a725e0a6b6ceed4a01569a1caced2c136042c778907244/garminconnect-0.3.3-py3-none-any.whl", hash = "sha256:e11dbbddf20abd60d5c8fbde1e7c688ca175a905237dfec8837ee935a1aca803", size = 47814, upload-time = "2026-04-22T12:57:23.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/6d69eb2eab9f62ed7e415a606c5ef63e19f27e561d15d7ac7d651997cfad/garminconnect-0.3.6-py3-none-any.whl", hash = "sha256:e05782ab90e63cb9c023407899e2d12dd18132316fd84394ebecd393809d4ffe", size = 57555, upload-time = "2026-06-14T08:05:36.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #25

## What

Adds a PySide6 desktop GUI so users can manage credentials, sync configuration, and run syncs without hand-editing JSON config files.

### Tabs
- **Credentials** - table view with add / edit / delete; passwords masked in the table and echo-hidden in the dialog. Strava hint: login = client_secret, password = refresh_token.
- **Configuration** - dynamic connector list (garmin / strava / local_folder), sync-group builder (sources with priority + destinations), date range with optional-custom checkboxes, force / skip-wellness toggles, and a Save button.
- **Sync** - "Run Sync" button, per-task progress bars mirroring the console renderer, error dialog on failure, and a "Show full log" button that opens `sync.log`.

### Design notes
- Config + credentials persist to a fixed location: `~/.config/trainings-sync/` (`config.json`, `credentials.json`, `cache/`).
- Sync runs in-process on a background `QThread` via `asyncio.run()`; task events are marshalled to the UI through Qt signals (`GuiRenderer` implements the existing `ProgressRenderer` interface).
- Atomic writes (`.tmp` then `.replace()`) for both config files.
- New console entry point: `trainings-sync-gui`.
- README documents installation of the GUI and a walkthrough of each tab.

## Testing
- `tests/gui/test_config_store.py` - full coverage of the store, serialization, and `AppConfig` conversion.
- `tests/gui/test_app.py` - pytest-qt widget behaviour tests (dialogs, tabs, task rows, log dialog, sync worker error path, main window).
- CI runs headless via `QT_QPA_PLATFORM=offscreen` with the required Qt system libraries installed on the runner.
- Full suite: 1075 passing, 99.12% coverage locally. `app/gui/app.py` and `app/tracking/gui_renderer.py` (thin Qt view/adapter layers) are excluded from the coverage gate.

## Review-fix cycles (each a separate commit)
1. Removed an unused `task_warning` Qt signal that was emitted but never connected.
2. Preserved Strava `credential_login` through the serialize -> load -> `to_app_config` round-trip.
3. Stored sync-group sources as item data instead of parsing `"id:priority"` text, fixing connector ids that contain a colon.
4. Wired a `SyncLogger` into the GUI sync so `sync.log` is actually written and the "Show full log" button has content.
5. Always close the sync logger and log unexpected errors, even when pipeline setup fails.
6. Use the system fixed-pitch font for the log dialog.
7. Ignore duplicate sources and destinations when building a sync group.