### PR TITLE
ci: release-please + portable per-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,94 @@
+name: build
+
+# Portable, self-contained builds of the GUI app. Users download one file for
+# their platform and run it - no Python/uv/git needed.
+#
+# On a pull request only a Linux x64 smoke build runs (fast, cheap). The full
+# platform matrix runs when a release is published and the artifacts are
+# attached to that GitHub Release.
+
+on:
+  pull_request:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # upload release assets
+
+env:
+  APP_NAME: trainings-sync
+
+jobs:
+  targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          full='{"include":[{"os":"ubuntu-22.04","name":"linux-x86_64"},{"os":"ubuntu-22.04-arm","name":"linux-aarch64"},{"os":"windows-latest","name":"windows-x64"},{"os":"windows-11-arm","name":"windows-arm64"},{"os":"macos-13","name":"macos-x86_64"},{"os":"macos-14","name":"macos-arm64"}]}'
+          smoke='{"include":[{"os":"ubuntu-22.04","name":"linux-x86_64"}]}'
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "matrix=$full" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$smoke" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: targets
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.targets.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install Qt system libraries (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libgl1 libegl1 libglib2.0-0 libdbus-1-3 libfontconfig1 libxkbcommon0
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Build portable app
+        shell: bash
+        run: |
+          set -euo pipefail
+          common=(--noconfirm --windowed --name "$APP_NAME" --collect-submodules app)
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --with pyinstaller pyinstaller "${common[@]}" app/gui/app.py
+            ( cd dist && zip -r -y "${APP_NAME}-${{ matrix.name }}.zip" "${APP_NAME}.app" )
+            echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.zip" >> "$GITHUB_ENV"
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            uv run --with pyinstaller pyinstaller --onefile "${common[@]}" app/gui/app.py
+            mv "dist/${APP_NAME}.exe" "dist/${APP_NAME}-${{ matrix.name }}.exe"
+            echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.exe" >> "$GITHUB_ENV"
+          else
+            uv run --with pyinstaller pyinstaller --onefile "${common[@]}" app/gui/app.py
+            mv "dist/${APP_NAME}" "dist/${APP_NAME}-${{ matrix.name }}"
+            echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify the artifact was produced
+        shell: bash
+        run: test -s "$ASSET"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ env.ASSET }}
+
+      - name: Attach to release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "$ASSET" --clobber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
   release:
     types: [published]
 
+# Cancel superseded pull-request builds, but never interrupt a release build.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write # upload release assets
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write # upload release assets
+  contents: read
 
 env:
   APP_NAME: trainings-sync
@@ -42,6 +42,8 @@ jobs:
 
   build:
     needs: targets
+    permissions:
+      contents: write # attach assets to the release
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.targets.outputs.matrix) }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: python


### PR DESCRIPTION
> [!IMPORTANT]
> **Before merging — enable release-please to run its pipeline.**
> In **Settings → Actions → General → Workflow permissions**: select **Read and write permissions** and tick **Allow GitHub Actions to create and approve pull requests**. Without this the release-please job cannot open its release PR after merge.

---

Adds automated releases and downloadable, self-contained apps so end users can just download one file for their platform and run it - no Python/uv/git needed.

## release-please
- `release-please.yml` runs on push to `main`, maintains a release PR (version bump in `pyproject.toml` + `CHANGELOG.md` from Conventional Commits), and cuts a GitHub Release when merged.

## Portable builds (`build.yml`)
- PyInstaller bundles the GUI (`app/gui/app.py`) into a single portable file per platform - no installer.
- **Pull requests:** only a Linux x64 smoke build runs (fast/cheap) to validate packaging.
- **On release published:** the full matrix builds and attaches assets to the release:
  - Windows x64 / ARM64 (`.exe`)
  - macOS x86-64 / arm64 (`.app` zipped, ad-hoc signed)
  - Linux x86-64 / aarch64 (single binary)

Notes:
- No code signing (macOS: one-time "Open Anyway"; Windows: SmartScreen "Run anyway"). Source is public for those who prefer to build their own.
- Config location is unchanged: `~/.config/trainings-sync/`.