### PR TITLE
fix: reliable release builds (linux-aarch64 glibc + drop Intel macOS)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - id: set
         shell: bash
         run: |
-          full='{"include":[{"os":"ubuntu-22.04","name":"linux-x86_64"},{"os":"ubuntu-22.04-arm","name":"linux-aarch64"},{"os":"windows-latest","name":"windows-x64"},{"os":"windows-11-arm","name":"windows-arm64"},{"os":"macos-13","name":"macos-x86_64"},{"os":"macos-14","name":"macos-arm64"}]}'
+          full='{"include":[{"os":"ubuntu-22.04","name":"linux-x86_64"},{"os":"ubuntu-24.04-arm","name":"linux-aarch64"},{"os":"windows-latest","name":"windows-x64"},{"os":"windows-11-arm","name":"windows-arm64"},{"os":"macos-14","name":"macos-arm64"}]}'
           smoke='{"include":[{"os":"ubuntu-22.04","name":"linux-x86_64"}]}'
           if [ -n "${{ inputs.release_tag }}" ]; then
             echo "matrix=$full" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Makes the release platform matrix build reliably. Two changes to `.github/workflows/build.yml`:

1. **linux-aarch64** — build on `ubuntu-24.04-arm` instead of `ubuntu-22.04-arm`. PySide6 6.11 aarch64 wheel is `manylinux_2_39` (needs glibc 2.39); Ubuntu 22.04 has only glibc 2.35, so `uv sync` failed. (x86_64 stays on 22.04.)
2. **macOS Intel (`macos-x86_64`)** — dropped. GitHub `macos-13` Intel runners are capacity-starved (jobs hang `queued` the whole 30-min timeout) and Intel macOS is being retired. macOS now ships a single `macos-arm64` build. Intel Macs can be re-added later via a universal2 build if wanted.

Clean 5-target matrix (linux x86_64/aarch64, windows x64/arm64, macos arm64), all reliable.

This is a `fix:` commit, so merging it makes release-please open a **new release PR (v0.1.1)**; merging that builds and attaches all 5 assets in the same run.