### PR TITLE
fix: progress counter loses its leading digits; document running a release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,75 @@
 
 CLI tool for syncing training activities between Garmin Connect and a local folder (FIT/GPX/TCX). Strava upload support is also available.
 
+## Download a ready-made app
+
+Every release ships portable builds, so there is nothing to install and no
+Python, uv or git needed. Pick the file for your platform from the
+[latest release](https://github.com/dchernykh1984/trainings_sync/releases/latest):
+
+| Platform | File |
+| --- | --- |
+| Windows (Intel/AMD) | `trainings-sync-windows-x64.exe` |
+| Windows (ARM) | `trainings-sync-windows-arm64.exe` |
+| macOS (Apple Silicon) | `trainings-sync-macos-arm64.zip` |
+| Linux (Intel/AMD) | `trainings-sync-linux-x86_64` |
+| Linux (ARM64) | `trainings-sync-linux-aarch64` |
+
+The builds are not code-signed, so every system needs a one-off nudge before the
+first launch. Each step below is done once per download, not on every start.
+
+### macOS
+
+Only Apple Silicon (M1 and newer) is supported - there is no Intel build.
+
+Unpack the archive, then clear the quarantine flag that macOS puts on downloaded
+files:
+
+```bash
+xattr -dr com.apple.quarantine "/path/to/trainings-sync.app"
+```
+
+After that the app opens with a normal double-click. Without it macOS refuses to
+start the app, because it is unsigned.
+
+The flag stays cleared. Copying or moving the app on the same Mac keeps it clear,
+so there is no need to repeat this for every copy. It only comes back when the app
+arrives from outside again: a fresh download, AirDrop, or unpacking a
+newly downloaded archive.
+
+Rather not use a terminal? Ctrl-click the app, choose **Open**, then **Open**
+again in the dialog. macOS 15 Sequoia dropped that shortcut - there, go to System
+Settings -> Privacy & Security, scroll down to the notice about the blocked app
+and press **Open Anyway**.
+
+### Windows
+
+Run the `.exe` directly. SmartScreen warns that the publisher is unknown: choose
+**More info**, then **Run anyway**.
+
+### Linux
+
+Make the file executable and run it:
+
+```bash
+chmod +x trainings-sync-linux-x86_64
+./trainings-sync-linux-x86_64
+```
+
+This is a GUI application, so it needs a graphical session. If it fails to start
+with an error about missing Qt libraries, install them:
+
+```bash
+sudo apt-get install -y libgl1 libegl1 libglib2.0-0 libdbus-1-3 \
+  libfontconfig1 libxkbcommon0
+```
+
+### Where to keep it
+
+Settings are stored under your home directory in `~/.config/trainings-sync/`, so the program
+itself can live anywhere - including `/Applications` on macOS.
+
+
 ## Setup
 
 ### 1. Download the project

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -264,6 +264,9 @@ def _parse_date_or_default(value: str, default: date) -> date:
 # ---------------------------------------------------------------------------
 
 
+_COUNT_MIN_WIDTH = 64
+
+
 class TaskRow(QWidget):
     def __init__(
         self, name: str, total: int | None, parent: QWidget | None = None
@@ -298,23 +301,46 @@ class TaskRow(QWidget):
         layout.addWidget(self._bar)
 
         self._count = QLabel("")
-        self._count.setFixedWidth(64)
+        self._count_chars = 0
+        self._count.setFixedWidth(_COUNT_MIN_WIDTH)
         self._count.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
+        if total is not None:
+            self._fit_count_width(f"{total}/{total}")
         layout.addWidget(self._count)
+
+    def _fit_count_width(self, text: str) -> None:
+        """Widen the counter so that `text` is not clipped.
+
+        The label is right-aligned with a fixed width, so anything too wide
+        loses its leading characters instead of its trailing ones: a task of
+        193372 items used to render as "36/193372". Sizing happens only when
+        the text grows longer, which keeps the column from jittering on every
+        progress tick.
+        """
+        if len(text) <= self._count_chars:
+            return
+        self._count_chars = len(text)
+        # Digits are the widest glyphs the counter shows, so measuring a run
+        # of them covers any value of the same length.
+        width = self._count.fontMetrics().horizontalAdvance("0" * len(text))
+        self._count.setFixedWidth(max(_COUNT_MIN_WIDTH, width + 8))
 
     def update_progress(self, progress: int) -> None:
         if self._total is not None:
             self._bar.setRange(0, self._total)
         self._bar.setValue(progress)
-        self._count.setText(
-            f"{progress}/{self._total}" if self._total is not None else str(progress)
-        )
+        text = f"{progress}/{self._total}" if self._total is not None else str(progress)
+        self._fit_count_width(text)
+        self._count.setText(text)
 
     def update_total(self, total: int) -> None:
         self._total = total
         self._bar.setRange(0, total)
+        # The total arrives after the row is built for tasks that discover
+        # their size later, so the counter has to be re-sized for it.
+        self._fit_count_width(f"{total}/{total}")
 
     def mark_done(self, warnings: list[str]) -> None:
         cap = max(1, self._total or 1)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -10,6 +10,7 @@ import pytest
 from PySide6.QtCore import Qt
 
 from app.gui.app import (
+    _COUNT_MIN_WIDTH,
     ConfigTab,
     ConnectorDialog,
     CredentialDialog,
@@ -914,6 +915,35 @@ def test_task_row_update_total(qtbot) -> None:
     row.update_total(20)
     assert row._total == 20
     assert row._bar.maximum() == 20
+
+
+def test_task_row_counter_fits_a_large_total(qtbot) -> None:
+    row = TaskRow("Wellness download", total=193372)
+    qtbot.addWidget(row)
+    row.update_progress(193336)
+    # The counter is right-aligned and fixed-width, so text that does not fit
+    # loses its leading characters: "193336/193372" used to show as
+    # "36/193372".
+    needed = row._count.fontMetrics().horizontalAdvance(row._count.text())
+    assert row._count.minimumWidth() >= needed
+
+
+def test_task_row_counter_fits_a_total_that_arrives_late(qtbot) -> None:
+    # Tasks that discover their size while running report the total after the
+    # row already exists, which is how the clipped counter was first seen.
+    row = TaskRow("Wellness download", total=None)
+    qtbot.addWidget(row)
+    row.update_total(193372)
+    row.update_progress(193336)
+    needed = row._count.fontMetrics().horizontalAdvance(row._count.text())
+    assert row._count.minimumWidth() >= needed
+
+
+def test_task_row_counter_keeps_its_width_for_small_totals(qtbot) -> None:
+    row = TaskRow("Task", total=5)
+    qtbot.addWidget(row)
+    row.update_progress(3)
+    assert row._count.minimumWidth() == _COUNT_MIN_WIDTH
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two commits.

## 1. `fix:` the sync progress counter

A task with a large total renders as `36/193372` instead of `193336/193372` - the current value is cut down to its last digits, so you cannot tell how far along it is.

**Cause.** The counter label is `setFixedWidth(64)` and right-aligned, so text that does not fit loses its *leading* characters. Measured in the app font:

| Text | Width |
| --- | --- |
| `3/10` | 25 px |
| `36/193372` | **63 px** |
| `193336/193372` | 92 px |

`36/193372` at 63 px is exactly the longest tail that fits inside 64 px, which is why that is what shows up.

**Fix.** The counter is now sized from its content: on construction from `{total}/{total}`, and again in `update_total()` - which matters, because tasks that discover their size while running (wellness download) report the total after the row already exists. Width is recomputed only when the text gets longer, so the column does not jitter across progress ticks, and `_COUNT_MIN_WIDTH` keeps the previous look for small numbers.

Three tests added: a large total set up front, a total that arrives late (the reported case), and small totals keeping the old width.

## 2. `docs:` how to run a release build

The portable builds shipped with no instructions, and on macOS they refuse to launch until the quarantine flag is cleared - not something a user can guess. Adds a **Download a ready-made app** section: asset table per platform, `xattr -dr com.apple.quarantine` with the reasoning and the Sequoia System Settings route, the Windows SmartScreen prompt, and `chmod +x` plus the Qt packages on Linux.

---

Note on versioning: the counter is a bug fix, so this is a `fix:` commit and release-please will propose **0.1.4** (patch). If you meant a semver *minor* bump to 0.2.0, say so and I will relabel the commit as `feat:`.