### PR TITLE
fix: GUI fixes, plus a stable connector id so renaming keeps the cache

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# Two pushes to main in quick succession would otherwise race over the
+# release branch, and the loser's push is rejected as non-fast-forward.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
     if: github.event_name == 'push'
@@ -26,6 +32,45 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           release-type: python
+
+      # release-please bumps pyproject.toml but knows nothing about uv.lock,
+      # whose own version field would stay behind - leaving every `uv sync`
+      # with a dirty tree and a lock that no longer matches the release.
+      - uses: astral-sh/setup-uv@v7
+        if: steps.rp.outputs.pr
+        with:
+          python-version: "3.14"
+
+      - name: Match uv.lock to the released version
+        if: steps.rp.outputs.pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ fromJSON(steps.rp.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+          git clone --branch "$BRANCH" --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
+            release-branch
+          cd release-branch
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already matches the released version"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -q -m "chore: match uv.lock to the released version" -- uv.lock
+          # release-please force-pushes this branch whenever it refreshes the
+          # PR. Losing that particular race is expected - the run that
+          # overtook us lands the same commit - but anything else is a real
+          # failure and must not pass silently.
+          if ! push=$(git push 2>&1); then
+            echo "$push"
+            echo "$push" | grep -q -e non-fast-forward -e "fetch first" \
+              || exit 1
+            echo "release branch moved on; the run that overtook us redoes this"
+          fi
 
   # Build the full platform matrix and upload the portable apps to the release,
   # in the same run (a GITHUB_TOKEN-created release cannot trigger a separate

--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ Build the sync configuration visually:
   dropdown (populated from the Credentials tab) - its URL and login come from
   that account. For a local folder pick the directory with **Browse...** (or type
   the path). A connector used by a sync group cannot be deleted until you remove
-  it from those groups.
+  it from those groups. Renaming a connector is safe: each one also carries a
+  hidden `uid` that never changes, and the cache is filed under that, so the
+  downloaded history stays attached to it.
 - **Sync Groups** - define what syncs where. Add sources (each with a priority;
   higher priority wins when the same activity exists in several sources) and
   destinations, both chosen from the connectors you defined.

--- a/app/cli.py
+++ b/app/cli.py
@@ -206,7 +206,7 @@ async def _run_sync(
         )
 
     strava_cred_map = {
-        c.id: c.credential
+        c.uid: c.credential
         for c in config.connectors
         if isinstance(c, StravaConnectorConfig)
     }
@@ -267,6 +267,7 @@ async def _run_sync(
             cache=cache,
             tracker=tracker,
             login_tasks=login_tasks,
+            uid_by_id={c.id: c.uid for c in config.connectors},
         )
         try:
             if not getattr(args, "skip_wellness", False):

--- a/app/cli.py
+++ b/app/cli.py
@@ -184,7 +184,11 @@ async def _run_wellness_concurrent(
             if isinstance(wc, LocalFolderWellnessConnector):
                 await wc.login()
         wellness_orch = WellnessOrchestrator(
-            wellness_connectors, wellness_cache, tracker, login_tasks=login_tasks
+            wellness_connectors,
+            wellness_cache,
+            tracker,
+            login_tasks=login_tasks,
+            names={c.uid: c.id for c in config.connectors},
         )
         await wellness_orch.run(start, end, force=args.force)
     except Exception as exc:

--- a/app/connectors/garmin_wellness.py
+++ b/app/connectors/garmin_wellness.py
@@ -69,9 +69,11 @@ class GarminWellnessConnector(WellnessConnector):
         tracker: TaskTracker,
         client: Garmin | None = None,
         parent_connector: GarminConnector | None = None,
+        display_name: str = "",
     ) -> None:
         super().__init__(tracker)
         self._connector_id = connector_id
+        self._display_name = display_name
         self._credentials = credentials
         self._client: Garmin | None = client
         self._parent_connector: GarminConnector | None = parent_connector
@@ -82,9 +84,11 @@ class GarminWellnessConnector(WellnessConnector):
         connector_id: str,
         garmin_connector: GarminConnector,
         tracker: TaskTracker,
+        display_name: str = "",
     ) -> GarminWellnessConnector:
         return cls(
             connector_id=connector_id,
+            display_name=display_name,
             credentials=garmin_connector._credentials,
             tracker=tracker,
             client=None,
@@ -145,7 +149,7 @@ class GarminWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.debug(
-                    f"[garmin-wellness] {self._connector_id}:"
+                    f"[garmin-wellness] {self.display_name}:"
                     f" fetch_daily({data_type.value}, {date_str}) failed: {exc}"
                 )
             return None
@@ -166,7 +170,7 @@ class GarminWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.debug(
-                    f"[garmin-wellness] {self._connector_id}:"
+                    f"[garmin-wellness] {self.display_name}:"
                     f" fetch_range({data_type.value},"
                     f" {start_str}, {end_str}) failed: {exc}"
                 )
@@ -288,7 +292,7 @@ class GarminWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.debug(
-                    f"[garmin-wellness] {self._connector_id}:"
+                    f"[garmin-wellness] {self.display_name}:"
                     f" fetch_snapshot({data_type.value}) failed: {exc}"
                 )
             return None
@@ -307,7 +311,7 @@ class GarminWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.warning(
-                    f"[garmin-wellness] {self._connector_id}:"
+                    f"[garmin-wellness] {self.display_name}:"
                     f" push_record({data_type.value}) failed: {exc}"
                 )
 

--- a/app/connectors/local_folder_wellness.py
+++ b/app/connectors/local_folder_wellness.py
@@ -18,10 +18,12 @@ class LocalFolderWellnessConnector(WellnessConnector):
         connector_id: str,
         folder: Path,
         tracker: object,
+        display_name: str = "",
     ) -> None:
 
         super().__init__(tracker)  # type: ignore[arg-type]
         self._connector_id = connector_id
+        self._display_name = display_name
         self._folder = folder
 
     @property

--- a/app/connectors/strava_wellness.py
+++ b/app/connectors/strava_wellness.py
@@ -22,9 +22,11 @@ class StravaWellnessConnector(WellnessConnector):
         connector_id: str,
         strava_connector: StravaConnector,
         tracker: TaskTracker,
+        display_name: str = "",
     ) -> None:
         super().__init__(tracker)
         self._connector_id = connector_id
+        self._display_name = display_name
         self._strava_connector = strava_connector
 
     @property
@@ -37,7 +39,7 @@ class StravaWellnessConnector(WellnessConnector):
 
     async def login(self) -> None:
         task_name = await self._tracker.add_task(
-            f"Strava wellness ({self._connector_id}): connect", total=1
+            f"Strava wellness ({self.display_name}): connect", total=1
         )
         await self._tracker.advance(task_name)
         await self._tracker.finish(task_name)
@@ -63,7 +65,7 @@ class StravaWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.debug(
-                    f"[strava-wellness] {self._connector_id}:"
+                    f"[strava-wellness] {self.display_name}:"
                     f" fetch_snapshot(athlete_stats) failed: {exc}"
                 )
             return None
@@ -76,7 +78,7 @@ class StravaWellnessConnector(WellnessConnector):
         except Exception as exc:
             if log:
                 log.debug(
-                    f"[strava-wellness] {self._connector_id}:"
+                    f"[strava-wellness] {self.display_name}:"
                     f" fetch_snapshot(athlete_zones) failed: {exc}"
                 )
             return None

--- a/app/connectors/wellness_base.py
+++ b/app/connectors/wellness_base.py
@@ -75,6 +75,16 @@ class WellnessConnector(ABC):
     @abstractmethod
     def connector_id(self) -> str: ...
 
+    @property
+    def display_name(self) -> str:
+        """What to call this connector in front of the user.
+
+        `connector_id` is the uid the cache is filed under, so it is not
+        something to show: for anything created in the GUI it is a hex
+        string.
+        """
+        return getattr(self, "_display_name", None) or self.connector_id
+
     @abstractmethod
     async def login(self) -> None: ...
 
@@ -104,7 +114,7 @@ class WellnessConnector(ABC):
         log = self._tracker.sync_logger
         if log:
             log.debug(
-                f"[wellness] {self.connector_id}: {method}({data_type.value})"
+                f"[wellness] {self.display_name}: {method}({data_type.value})"
                 " not supported - skipped"
             )
 

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -22,7 +22,7 @@ def _file_exists(path: Path) -> bool:
 @dataclass(frozen=True)
 class CacheEntry:
     external_id: str
-    source_id: str  # stable id from config, e.g. "garmin-main"
+    source_id: str  # the connector's uid - never its display name
     format: str  # "fit", "gpx", "tcx"
     start_time: datetime  # UTC
     elapsed_s: int | None  # wall-clock duration; None if unknown

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,10 +8,15 @@ from pathlib import Path
 from app.credentials.base import CredentialRequest
 
 
+# `id` is the display name and the user is free to change it. `uid` is the
+# connector's stable identity: it never changes, so the cache can follow a
+# connector across renames instead of being silently orphaned. Configs written
+# before uids existed simply get uid == id (see `_parse_connector`).
 @dataclass(frozen=True)
 class GarminConnectorConfig:
     id: str
     credential: CredentialRequest
+    uid: str = ""
 
 
 @dataclass(frozen=True)
@@ -19,12 +24,14 @@ class StravaConnectorConfig:
     id: str
     client_id: int
     credential: CredentialRequest
+    uid: str = ""
 
 
 @dataclass(frozen=True)
 class LocalFolderConnectorConfig:
     id: str
     folder: Path
+    uid: str = ""
 
 
 ConnectorConfig = (
@@ -114,14 +121,24 @@ def _parse_connector(raw: object, index: int, base_dir: Path) -> ConnectorConfig
 
     connector_type = _require_str(raw, "type", where)
 
+    # A config written before uids existed keeps working: the connector's
+    # current name becomes its stable identity, which is exactly what the
+    # cache is already keyed by, so nothing has to be rewritten.
+    raw_uid = raw.get("uid", "")
+    if not isinstance(raw_uid, str):
+        raise ConfigError(f"{where}: 'uid' must be a string")
+    connector_uid = raw_uid or connector_id
+
     if connector_type == "garmin":
         return GarminConnectorConfig(
             id=connector_id,
+            uid=connector_uid,
             credential=_parse_credential(raw, where),
         )
     if connector_type == "strava":
         return StravaConnectorConfig(
             id=connector_id,
+            uid=connector_uid,
             client_id=_require_int(raw, "client_id", where),
             credential=_parse_credential(raw, where),
         )
@@ -129,6 +146,7 @@ def _parse_connector(raw: object, index: int, base_dir: Path) -> ConnectorConfig
         folder_str = _require_str(raw, "folder", where)
         return LocalFolderConnectorConfig(
             id=connector_id,
+            uid=connector_uid,
             folder=_resolve_path(folder_str, base_dir),
         )
     raise ConfigError(f"{where}: unknown connector type {connector_type!r}")
@@ -219,7 +237,7 @@ def _check_unique_ids(ids: list[str], label: str) -> None:
     seen: set[str] = set()
     for sid in ids:
         if sid in seen:
-            raise ConfigError(f"duplicate {label} id: {sid!r}")
+            raise ConfigError(f"duplicate {label}: {sid!r}")
         seen.add(sid)
 
 
@@ -266,7 +284,10 @@ def load_config(path: Path) -> AppConfig:
     connectors = tuple(
         _parse_connector(c, i, base_dir) for i, c in enumerate(raw_connectors)
     )
-    _check_unique_ids([c.id for c in connectors], "connector")
+    _check_unique_ids([c.id for c in connectors], "connector id")
+    # A shared uid reads as "this connector was renamed", so a duplicate
+    # would hand one connector's cached history to another.
+    _check_unique_ids([c.uid for c in connectors], "connector uid")
     _check_strava_credential_uniqueness(connectors)
 
     raw_groups = raw.get("sync_groups", [])
@@ -279,7 +300,7 @@ def load_config(path: Path) -> AppConfig:
     sync_groups = tuple(
         _parse_group(g, i, connector_ids) for i, g in enumerate(raw_groups)
     )
-    _check_unique_ids([g.id for g in sync_groups], "sync group")
+    _check_unique_ids([g.id for g in sync_groups], "sync group id")
 
     start = _parse_date_optional(raw, "start", "root")
     end = _parse_date_optional(raw, "end", "root")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,14 @@ class GarminConnectorConfig:
     credential: CredentialRequest
     uid: str = ""
 
+    def __post_init__(self) -> None:
+        # A config built in code rather than parsed still needs an identity:
+        # an empty one would collapse every such connector onto a single
+        # cache key. The name is the only sensible stand-in, and it is what a
+        # pre-uid config file gets too.
+        if not self.uid:
+            object.__setattr__(self, "uid", self.id)
+
 
 @dataclass(frozen=True)
 class StravaConnectorConfig:
@@ -26,12 +34,28 @@ class StravaConnectorConfig:
     credential: CredentialRequest
     uid: str = ""
 
+    def __post_init__(self) -> None:
+        # A config built in code rather than parsed still needs an identity:
+        # an empty one would collapse every such connector onto a single
+        # cache key. The name is the only sensible stand-in, and it is what a
+        # pre-uid config file gets too.
+        if not self.uid:
+            object.__setattr__(self, "uid", self.id)
+
 
 @dataclass(frozen=True)
 class LocalFolderConnectorConfig:
     id: str
     folder: Path
     uid: str = ""
+
+    def __post_init__(self) -> None:
+        # A config built in code rather than parsed still needs an identity:
+        # an empty one would collapse every such connector onto a single
+        # cache key. The name is the only sensible stand-in, and it is what a
+        # pre-uid config file gets too.
+        if not self.uid:
+            object.__setattr__(self, "uid", self.id)
 
 
 ConnectorConfig = (

--- a/app/core/connector_factory.py
+++ b/app/core/connector_factory.py
@@ -62,11 +62,11 @@ async def build_connectors(
             connector = StravaConnector(
                 credentials=strava_creds,
                 tracker=tracker,
-                on_token_refresh=_strava_callback(cfg.id, on_strava_token_refresh),
+                on_token_refresh=_strava_callback(cfg.uid, on_strava_token_refresh),
             )
         else:  # LocalFolderConnectorConfig - source mode (no cache/dest_id)
             connector = LocalFolderConnector(folder=cfg.folder, tracker=tracker)
-        result[cfg.id] = connector
+        result[cfg.uid] = connector
 
     return result
 
@@ -84,20 +84,20 @@ async def build_wellness_connectors(
     result: dict[str, WellnessConnector] = {}
     for cfg in config.connectors:
         if isinstance(cfg, GarminConnectorConfig):
-            activity_conn = activity_connectors.get(cfg.id)
+            activity_conn = activity_connectors.get(cfg.uid)
             if isinstance(activity_conn, GarminConnector):
                 connector: WellnessConnector = (
                     GarminWellnessConnector.from_garmin_connector(
-                        cfg.id, activity_conn, tracker
+                        cfg.uid, activity_conn, tracker
                     )
                 )
             else:
                 continue
         elif isinstance(cfg, StravaConnectorConfig):
-            activity_conn = activity_connectors.get(cfg.id)
+            activity_conn = activity_connectors.get(cfg.uid)
             if isinstance(activity_conn, StravaConnector):
                 connector = StravaWellnessConnector(
-                    connector_id=cfg.id,
+                    connector_id=cfg.uid,
                     strava_connector=activity_conn,
                     tracker=tracker,
                 )
@@ -105,21 +105,32 @@ async def build_wellness_connectors(
                 continue
         elif isinstance(cfg, LocalFolderConnectorConfig):
             connector = LocalFolderWellnessConnector(
-                connector_id=cfg.id,
+                connector_id=cfg.uid,
                 folder=cfg.folder,
                 tracker=tracker,
             )
         else:
             continue
-        result[cfg.id] = connector
+        result[cfg.uid] = connector
     return result
 
 
 def resolve_group_sources(
-    group: SyncGroupConfig, connectors: dict[str, ServiceConnector]
+    group: SyncGroupConfig,
+    connectors: dict[str, ServiceConnector],
+    uid_by_id: dict[str, str] | None = None,
 ) -> list[tuple[SourceSpec, ServiceConnector]]:
+    """Resolve a group's source names to the uids everything else works by.
+
+    Without a mapping the names are taken to be the uids, which is what a
+    config predating uids amounts to.
+    """
+    uid_by_id = uid_by_id or {cid: cid for cid in connectors}
     return [
-        (SourceSpec(source_id=src.id, priority=src.priority), connectors[src.id])
+        (
+            SourceSpec(source_id=uid_by_id[src.id], priority=src.priority),
+            connectors[uid_by_id[src.id]],
+        )
         for src in group.sources
     ]
 
@@ -128,11 +139,14 @@ def resolve_group_destinations(
     group: SyncGroupConfig,
     connectors: dict[str, ServiceConnector],
     cache: object,
+    uid_by_id: dict[str, str] | None = None,
 ) -> list[tuple[str, ServiceConnector]]:
+    uid_by_id = uid_by_id or {cid: cid for cid in connectors}
     result: list[tuple[str, ServiceConnector]] = []
-    for dest_id in group.destinations:
-        connector = connectors[dest_id]
+    for name in group.destinations:
+        uid = uid_by_id[name]
+        connector = connectors[uid]
         if isinstance(connector, LocalFolderConnector):
-            connector = connector.as_destination(cache, dest_id)
-        result.append((dest_id, connector))
+            connector = connector.as_destination(cache, uid)
+        result.append((uid, connector))
     return result

--- a/app/core/connector_factory.py
+++ b/app/core/connector_factory.py
@@ -88,7 +88,7 @@ async def build_wellness_connectors(
             if isinstance(activity_conn, GarminConnector):
                 connector: WellnessConnector = (
                     GarminWellnessConnector.from_garmin_connector(
-                        cfg.uid, activity_conn, tracker
+                        cfg.uid, activity_conn, tracker, display_name=cfg.id
                     )
                 )
             else:
@@ -100,6 +100,7 @@ async def build_wellness_connectors(
                     connector_id=cfg.uid,
                     strava_connector=activity_conn,
                     tracker=tracker,
+                    display_name=cfg.id,
                 )
             else:
                 continue
@@ -108,6 +109,7 @@ async def build_wellness_connectors(
                 connector_id=cfg.uid,
                 folder=cfg.folder,
                 tracker=tracker,
+                display_name=cfg.id,
             )
         else:
             continue

--- a/app/core/connector_factory.py
+++ b/app/core/connector_factory.py
@@ -118,14 +118,9 @@ async def build_wellness_connectors(
 def resolve_group_sources(
     group: SyncGroupConfig,
     connectors: dict[str, ServiceConnector],
-    uid_by_id: dict[str, str] | None = None,
+    uid_by_id: dict[str, str],
 ) -> list[tuple[SourceSpec, ServiceConnector]]:
-    """Resolve a group's source names to the uids everything else works by.
-
-    Without a mapping the names are taken to be the uids, which is what a
-    config predating uids amounts to.
-    """
-    uid_by_id = uid_by_id or {cid: cid for cid in connectors}
+    """Resolve a group's source names to the uids everything else works by."""
     return [
         (
             SourceSpec(source_id=uid_by_id[src.id], priority=src.priority),
@@ -139,9 +134,8 @@ def resolve_group_destinations(
     group: SyncGroupConfig,
     connectors: dict[str, ServiceConnector],
     cache: object,
-    uid_by_id: dict[str, str] | None = None,
+    uid_by_id: dict[str, str],
 ) -> list[tuple[str, ServiceConnector]]:
-    uid_by_id = uid_by_id or {cid: cid for cid in connectors}
     result: list[tuple[str, ServiceConnector]] = []
     for name in group.destinations:
         uid = uid_by_id[name]

--- a/app/core/orchestrator.py
+++ b/app/core/orchestrator.py
@@ -18,9 +18,9 @@ class SyncOrchestrator:
         groups: tuple[SyncGroupConfig, ...],
         connectors: dict[str, ServiceConnector],
         cache: ActivityCache,
+        uid_by_id: dict[str, str],
         tracker: TaskTracker | None = None,
         login_tasks: dict[str, asyncio.Task[None]] | None = None,
-        uid_by_id: dict[str, str] | None = None,
     ) -> None:
         self._groups = groups
         self._connectors = connectors
@@ -29,8 +29,10 @@ class SyncOrchestrator:
         self._login_tasks = login_tasks
         # Everything downstream is keyed by uid so that renaming a connector
         # leaves the cache untouched; the names are kept only to say who is
-        # who in the log and in the task list.
-        self._uid_by_id = uid_by_id or {cid: cid for cid in connectors}
+        # who in the log and in the task list. Required rather than
+        # defaulted: an identity map silently turns every name lookup into
+        # a crash and every label into a hex string.
+        self._uid_by_id = uid_by_id
         self._names = {uid: name for name, uid in self._uid_by_id.items()}
 
     async def run(self, start: date, end: date, *, force: bool = False) -> int:

--- a/app/core/orchestrator.py
+++ b/app/core/orchestrator.py
@@ -137,7 +137,12 @@ class SyncOrchestrator:
         end: date,
     ) -> None:
         log = self._tracker.sync_logger if self._tracker is not None else None
-        conn_ids = sorted({src.id for src in group.sources} | set(group.destinations))
+        # The locks are keyed by uid like everything else; the group still
+        # names its connectors, so translate before reaching for them.
+        conn_ids = sorted(
+            {self._uid_by_id[src.id] for src in group.sources}
+            | {self._uid_by_id[name] for name in group.destinations}
+        )
         acquired: list[asyncio.Lock] = []
         try:
             for conn_id in conn_ids:

--- a/app/core/orchestrator.py
+++ b/app/core/orchestrator.py
@@ -20,19 +20,29 @@ class SyncOrchestrator:
         cache: ActivityCache,
         tracker: TaskTracker | None = None,
         login_tasks: dict[str, asyncio.Task[None]] | None = None,
+        uid_by_id: dict[str, str] | None = None,
     ) -> None:
         self._groups = groups
         self._connectors = connectors
         self._cache = cache
         self._tracker = tracker
         self._login_tasks = login_tasks
+        # Everything downstream is keyed by uid so that renaming a connector
+        # leaves the cache untouched; the names are kept only to say who is
+        # who in the log and in the task list.
+        self._uid_by_id = uid_by_id or {cid: cid for cid in connectors}
+        self._names = {uid: name for name, uid in self._uid_by_id.items()}
 
     async def run(self, start: date, end: date, *, force: bool = False) -> int:
         list_cache: dict[tuple[str, date, date], list[ActivityMeta]] = {}
 
         # Collect unique source IDs in declaration order across all groups.
         unique_source_ids: list[str] = list(
-            dict.fromkeys(src.id for group in self._groups for src in group.sources)
+            dict.fromkeys(
+                self._uid_by_id[src.id]
+                for group in self._groups
+                for src in group.sources
+            )
         )
         source_executors = [
             self._build_source_executor(src_id, list_cache)
@@ -75,6 +85,7 @@ class SyncOrchestrator:
             task_prefix="",
             login_tasks=self._login_tasks,
             list_cache=list_cache,
+            names=self._names,
         )
 
     def _build_executor(
@@ -83,15 +94,16 @@ class SyncOrchestrator:
         list_cache: dict[tuple[str, date, date], list[ActivityMeta]],
     ) -> SyncExecutor:
         return SyncExecutor(
-            sources=resolve_group_sources(group, self._connectors),
+            sources=resolve_group_sources(group, self._connectors, self._uid_by_id),
             destinations=resolve_group_destinations(
-                group, self._connectors, self._cache
+                group, self._connectors, self._cache, self._uid_by_id
             ),
             cache=self._cache,
             tracker=self._tracker,
             task_prefix=f"{group.id}: ",
             login_tasks=self._login_tasks,
             list_cache=list_cache,
+            names=self._names,
         )
 
     async def _download_source_phase(
@@ -104,16 +116,17 @@ class SyncOrchestrator:
         force: bool,
     ) -> None:
         log = self._tracker.sync_logger if self._tracker is not None else None
+        name = self._names.get(source_id, source_id)
         if log is not None:
-            log.info(f"[source] {source_id} - download started")
+            log.info(f"[source] {name} - download started")
         try:
             await executor.download_phase(start, end, force=force)
         except BaseException:
             if log is not None:
-                log.error(f"[source] {source_id} - download failed")
+                log.error(f"[source] {name} - download failed")
             raise
         if log is not None:
-            log.info(f"[source] {source_id} - download done")
+            log.info(f"[source] {name} - download done")
 
     async def _upload_group_locked(
         self,

--- a/app/core/sync.py
+++ b/app/core/sync.py
@@ -150,6 +150,7 @@ class SyncExecutor:
         task_prefix: str = "",
         login_tasks: dict[str, asyncio.Task[None]] | None = None,
         list_cache: dict[tuple[str, date, date], list[ActivityMeta]] | None = None,
+        names: dict[str, str] | None = None,
     ) -> None:
         source_ids = [spec.source_id for spec, _ in sources]
         if len(source_ids) != len(set(source_ids)):
@@ -166,7 +167,14 @@ class SyncExecutor:
         self._task_prefix = task_prefix
         self._login_tasks = login_tasks
         self._list_cache = list_cache
+        # Ids here are uids, so that renaming a connector never touches the
+        # cache. These are what to call them in front of the user.
+        self._names = names or {}
         self._download_failures: int = 0
+
+    def _name(self, connector_id: str) -> str:
+        """What to call a connector in the log and the task list."""
+        return self._names.get(connector_id, connector_id)
 
     @property
     def download_failures(self) -> int:
@@ -235,7 +243,7 @@ class SyncExecutor:
                     continue  # new 429 since we waited; loop back to wait
                 if attempt > 0 and not _start_logged and log:
                     log.info(
-                        f"[download] {source_id}{account}:"
+                        f"[download] {self._name(source_id)}{account}:"
                         f" {item.meta.external_id!r} - attempt"
                         f" {attempt + 1}/{_DOWNLOAD_ATTEMPTS} starting"
                     )
@@ -273,14 +281,14 @@ class SyncExecutor:
             stored = self._cache_activity(source_id, activity)
             if log:
                 log.info(
-                    f"[download] {source_id}{account}:"
+                    f"[download] {self._name(source_id)}{account}:"
                     f" {activity.external_id!r}"
                     f" {activity.start_time.date()}"
                     f' "{activity.name}" -> {stored.filename}'
                 )
         elif log:
             log.info(
-                f"[download] {source_id}{account}:"
+                f"[download] {self._name(source_id)}{account}:"
                 f" {meta.external_id!r} - unavailable, skipped"
             )
         if not advanced and tracking is not None:
@@ -301,7 +309,7 @@ class SyncExecutor:
         if isinstance(exc, RateLimitError):
             if log:
                 log.warning(
-                    f"[download] {source_id}{account}:"
+                    f"[download] {self._name(source_id)}{account}:"
                     f" {external_id!r} - rate limited (download failed)"
                 )
             return 0.0, advanced
@@ -313,14 +321,14 @@ class SyncExecutor:
         if log:
             if has_next:
                 log.warning(
-                    f"[download] {source_id}{account}:"
+                    f"[download] {self._name(source_id)}{account}:"
                     f" {external_id!r} - attempt"
                     f" {attempt + 1}/{_DOWNLOAD_ATTEMPTS} failed ({exc}),"
                     f" sleeping {_DOWNLOAD_RETRY_DELAY_S:.0f}s before retry"
                 )
             else:
                 log.warning(
-                    f"[download] {source_id}{account}:"
+                    f"[download] {self._name(source_id)}{account}:"
                     f" {external_id!r} - attempt"
                     f" {attempt + 1}/{_DOWNLOAD_ATTEMPTS} failed ({exc})"
                 )
@@ -376,7 +384,7 @@ class SyncExecutor:
                     and log
                 ):
                     log.info(
-                        f"[download] {source_id}{account}:"
+                        f"[download] {self._name(source_id)}{account}:"
                         f" pausing all downloads for {rate_state.last_pause_s:.0f}s"
                     )
                 continue
@@ -386,7 +394,7 @@ class SyncExecutor:
             return 0
         if log:
             log.error(
-                f"[download] {source_id}{account}:"
+                f"[download] {self._name(source_id)}{account}:"
                 f" {item.meta.external_id!r} - all {_DOWNLOAD_ATTEMPTS} attempts"
                 f" failed ({last_exc})"
             )
@@ -443,7 +451,9 @@ class SyncExecutor:
                 spec, _ = source_metas[0]
                 label = self._source_user_label(spec.source_id)
                 src_part = (
-                    f" {spec.source_id} ({label})" if label else f" {spec.source_id}"
+                    f" {self._name(spec.source_id)} ({label})"
+                    if label
+                    else f" {self._name(spec.source_id)}"
                 )
             else:
                 src_part = ""
@@ -484,7 +494,7 @@ class SyncExecutor:
             label = self._source_user_label(spec.source_id)
             account = f" ({label})" if label else ""
             log.info(
-                f"[plan] {spec.source_id}{account}:"
+                f"[plan] {self._name(spec.source_id)}{account}:"
                 f" {to_dl} to download, {len(metas) - to_dl} skipped"
             )
 
@@ -539,8 +549,9 @@ class SyncExecutor:
             for source_id, items in by_source.items():
                 label = source_map[source_id].user_label
                 suffix = f" ({label})" if label else ""
+                name = self._name(source_id)
                 source_task_names[source_id] = await tracker.add_task(
-                    f"{self._task_prefix}Download {source_id}{suffix} activities",
+                    f"{self._task_prefix}Download {name}{suffix} activities",
                     total=len(items),
                 )
 
@@ -596,11 +607,12 @@ class SyncExecutor:
         if dest_id is not None:
             dest_label = self._dest_user_label(dest_id)
             dest_suffix = f" ({dest_label})" if dest_label else ""
-            where = f" -> {dest_id}{dest_suffix}"
+            where = f" -> {self._name(dest_id)}{dest_suffix}"
         else:
             where = ""
+        src_name = self._name(entry.source_id)
         log.debug(
-            f"[upload-plan] {entry.source_id}{src_suffix}: {entry.external_id!r}"
+            f"[upload-plan] {src_name}{src_suffix}: {entry.external_id!r}"
             f" {entry.start_time.date()}{where}: {reason}"
         )
 
@@ -803,7 +815,7 @@ class SyncExecutor:
         await tracking[0].warn(
             tracking[1],
             f"{external_id!r}: {n_items} media item(s) not uploaded"
-            f" to {dest_id} (not supported)",
+            f" to {self._name(dest_id)} (not supported)",
         )
 
     def _build_upload_activity(
@@ -867,8 +879,8 @@ class SyncExecutor:
                     src_suffix = f" ({src_label})" if src_label else ""
                     log.info(
                         f"[upload] {entry.external_id!r}"
-                        f" ({entry.source_id}{src_suffix})"
-                        f" -> {dest_id}{dest_suffix}: {result}"
+                        f" ({self._name(entry.source_id)}{src_suffix})"
+                        f" -> {self._name(dest_id)}{dest_suffix}: {result}"
                     )
                 if tracking is not None:
                     await tracking[0].advance(tracking[1])
@@ -947,7 +959,7 @@ class SyncExecutor:
                 label = dest_map[dest_id].user_label
                 suffix = f" ({label})" if label else ""
                 dest_task_names[dest_id] = await tracker.add_task(
-                    f"{self._task_prefix}Upload to {dest_id}{suffix}",
+                    f"{self._task_prefix}Upload to {self._name(dest_id)}{suffix}",
                     total=len(entries),
                 )
 

--- a/app/core/sync.py
+++ b/app/core/sync.py
@@ -655,7 +655,7 @@ class SyncExecutor:
                 shadower_label = self._source_user_label(shadower)
                 shadower_suffix = f" ({shadower_label})" if shadower_label else ""
                 self._log_upload_decision(
-                    entry, None, f"shadowed by {shadower}{shadower_suffix}"
+                    entry, None, f"shadowed by {self._name(shadower)}{shadower_suffix}"
                 )
             else:
                 for dest_id, connector in self._destinations:
@@ -701,10 +701,11 @@ class SyncExecutor:
                 collected.append(item)
             added = len(collected) - before
             if log and added:
+                winner_name = self._name(winner.source_id)
                 log.debug(
-                    f"[upload-plan] {winner.source_id}: {winner.external_id!r}"
+                    f"[upload-plan] {winner_name}: {winner.external_id!r}"
                     f" borrows {added} media item(s)"
-                    f" from {donor.source_id}: {donor.external_id!r}"
+                    f" from {self._name(donor.source_id)}: {donor.external_id!r}"
                 )
         return collected
 

--- a/app/core/wellness_orchestrator.py
+++ b/app/core/wellness_orchestrator.py
@@ -21,16 +21,17 @@ class WellnessOrchestrator:
         connectors: dict[str, WellnessConnector],
         cache: WellnessCache,
         tracker: TaskTracker,
+        names: dict[str, str],
         login_tasks: dict[str, asyncio.Task[None]] | None = None,
-        names: dict[str, str] | None = None,
     ) -> None:
         self._connectors = connectors
         self._cache = cache
         self._tracker = tracker
         self._login_tasks: dict[str, asyncio.Task[None]] = login_tasks or {}
         # Connectors are keyed by uid so a rename never moves cached data;
-        # these are what to call them in the task list.
-        self._names = names or {}
+        # these are what to call them in the task list. Required, so that
+        # forgetting to wire it cannot silently show hex strings.
+        self._names = names
 
     def _name(self, connector_id: str) -> str:
         """What to call a connector in the task list."""

--- a/app/core/wellness_orchestrator.py
+++ b/app/core/wellness_orchestrator.py
@@ -22,11 +22,19 @@ class WellnessOrchestrator:
         cache: WellnessCache,
         tracker: TaskTracker,
         login_tasks: dict[str, asyncio.Task[None]] | None = None,
+        names: dict[str, str] | None = None,
     ) -> None:
         self._connectors = connectors
         self._cache = cache
         self._tracker = tracker
         self._login_tasks: dict[str, asyncio.Task[None]] = login_tasks or {}
+        # Connectors are keyed by uid so a rename never moves cached data;
+        # these are what to call them in the task list.
+        self._names = names or {}
+
+    def _name(self, connector_id: str) -> str:
+        """What to call a connector in the task list."""
+        return self._names.get(connector_id, connector_id)
 
     async def run(self, start: date, end: date, *, force: bool = False) -> None:
         sources = {
@@ -95,7 +103,7 @@ class WellnessOrchestrator:
             return
 
         task_name = await self._tracker.add_task(
-            f"Wellness download ({connector_id})", total=total
+            f"Wellness download ({self._name(connector_id)})", total=total
         )
         sem = asyncio.Semaphore(_MAX_CONCURRENT)
 
@@ -187,7 +195,8 @@ class WellnessOrchestrator:
             return
 
         task_name = await self._tracker.add_task(
-            f"Wellness upload ({dest.connector_id})", total=len(push_items)
+            f"Wellness upload ({self._name(dest.connector_id)})",
+            total=len(push_items),
         )
         for push_dt, push_d, push_key, push_source_id in push_items:
             data = self._cache.read(push_source_id, push_dt, push_key)

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -267,13 +267,46 @@ def _parse_date_or_default(value: str, default: date) -> date:
 _COUNT_MIN_WIDTH = 64
 
 
+class CounterColumn:
+    """One counter width shared by every row, so the bars stay in a column.
+
+    Rows lay themselves out on their own, so sizing each counter to its own
+    text would let a row counting to 193372 push its progress bar left of the
+    others. Instead the widest counter wins and every row adopts that width.
+    """
+
+    def __init__(self) -> None:
+        self._width = _COUNT_MIN_WIDTH
+        self._rows: list[TaskRow] = []
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    def add(self, row: TaskRow) -> None:
+        self._rows.append(row)
+        row.apply_count_width(self._width)
+
+    def require(self, width: int) -> None:
+        if width <= self._width:
+            return
+        self._width = width
+        for row in self._rows:
+            row.apply_count_width(width)
+
+
 class TaskRow(QWidget):
     def __init__(
-        self, name: str, total: int | None, parent: QWidget | None = None
+        self,
+        name: str,
+        total: int | None,
+        parent: QWidget | None = None,
+        column: CounterColumn | None = None,
     ) -> None:
         super().__init__(parent)
         self._name = name
         self._total = total
+        self._column = column if column is not None else CounterColumn()
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 2, 4, 2)
@@ -302,22 +335,25 @@ class TaskRow(QWidget):
 
         self._count = QLabel("")
         self._count_chars = 0
-        self._count.setFixedWidth(_COUNT_MIN_WIDTH)
         self._count.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
+        self._column.add(self)
         if total is not None:
             self._fit_count_width(f"{total}/{total}")
         layout.addWidget(self._count)
 
-    def _fit_count_width(self, text: str) -> None:
-        """Widen the counter so that `text` is not clipped.
+    def apply_count_width(self, width: int) -> None:
+        """Adopt the shared counter width. Called by :class:`CounterColumn`."""
+        self._count.setFixedWidth(width)
 
-        The label is right-aligned with a fixed width, so anything too wide
-        loses its leading characters instead of its trailing ones: a task of
-        193372 items used to render as "36/193372". Sizing happens only when
-        the text grows longer, which keeps the column from jittering on every
-        progress tick.
+    def _fit_count_width(self, text: str) -> None:
+        """Ask the shared column to make room for `text`.
+
+        The counter is right-aligned with a fixed width, so text that does not
+        fit loses its leading characters instead of its trailing ones: a task
+        of 193372 items rendered as "36/193372". Only a longer text triggers a
+        request, which keeps the column from being recomputed on every tick.
         """
         if len(text) <= self._count_chars:
             return
@@ -325,7 +361,7 @@ class TaskRow(QWidget):
         # Digits are the widest glyphs the counter shows, so measuring a run
         # of them covers any value of the same length.
         width = self._count.fontMetrics().horizontalAdvance("0" * len(text))
-        self._count.setFixedWidth(max(_COUNT_MIN_WIDTH, width + 8))
+        self._column.require(max(_COUNT_MIN_WIDTH, width + 8))
 
     def update_progress(self, progress: int) -> None:
         if self._total is not None:
@@ -1249,6 +1285,7 @@ class SyncTab(QWidget):
         self._config_tab = config_tab
         self._worker: SyncWorker | None = None
         self._task_rows: dict[str, TaskRow] = {}
+        self._counter_column = CounterColumn()
 
         root = QVBoxLayout(self)
 
@@ -1295,6 +1332,9 @@ class SyncTab(QWidget):
                 if widget is not None:
                     widget.deleteLater()
         self._task_rows.clear()
+        # A fresh run starts the counter column over, so a previous run's wide
+        # totals do not leave every row padded.
+        self._counter_column = CounterColumn()
 
         renderer = GuiRenderer()
         sigs = renderer.signals
@@ -1375,7 +1415,10 @@ class SyncTab(QWidget):
 
     def _on_task_added(self, name: str, total: object) -> None:
         row = TaskRow(
-            name, total if isinstance(total, int) else None, self._task_container
+            name,
+            total if isinstance(total, int) else None,
+            self._task_container,
+            column=self._counter_column,
         )
         self._task_rows[name] = row
         # Insert before the trailing stretch

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -94,16 +94,45 @@ class SyncWorker(QThread):
         self._gui_config = gui_config
         self._renderer = renderer
         self._keepass_passwords = keepass_passwords or {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._task: asyncio.Task[int] | None = None
+        self._cancelled = False
 
     def run(self) -> None:
         ts_start = datetime.now().astimezone().isoformat(timespec="seconds")
         self.started_ts.emit(ts_start)
         try:
-            failures = asyncio.run(self._async_sync())
-            ts_end = datetime.now().astimezone().isoformat(timespec="seconds")
-            self.finished_ts.emit(ts_end, failures)
+            failures = asyncio.run(self._run_cancellable())
+        except asyncio.CancelledError:
+            return  # asked to stop so the app can quit; nothing to report
         except Exception as exc:
             self.error_occurred.emit(str(exc))
+            return
+        ts_end = datetime.now().astimezone().isoformat(timespec="seconds")
+        self.finished_ts.emit(ts_end, failures)
+
+    async def _run_cancellable(self) -> int:
+        # Publish the loop and task so cancel() can reach them from the GUI
+        # thread; asyncio.run() creates the loop, so it cannot be captured
+        # before the coroutine is already running.
+        self._loop = asyncio.get_running_loop()
+        self._task = asyncio.current_task()  # type: ignore[assignment]
+        if self._cancelled:
+            # cancel() landed in the gap between start() and this line, where
+            # there was no task to cancel yet.
+            raise asyncio.CancelledError
+        return await self._async_sync()
+
+    def cancel(self) -> None:
+        """Ask a running sync to stop. Safe to call from the GUI thread."""
+        self._cancelled = True
+        loop, task = self._loop, self._task
+        if loop is None or task is None:
+            return  # not armed yet; _run_cancellable picks up the flag
+        try:
+            loop.call_soon_threadsafe(task.cancel)
+        except RuntimeError:
+            pass  # the loop already finished - nothing left to cancel
 
     async def _async_sync(self) -> int:
         from app.core.cache import ActivityCache
@@ -1316,6 +1345,17 @@ class SyncTab(QWidget):
         self._log_btn.clicked.connect(self._show_log)
 
     def _run_sync(self) -> None:
+        # A previous run may still be unwinding after a stop that overran its
+        # budget. Starting now would leave two writers on one cache index, and
+        # rebinding self._worker would destroy a live QThread.
+        if self._worker is not None and self._worker.isRunning():
+            QMessageBox.information(
+                self,
+                "Sync in progress",
+                "The previous sync is still stopping. Try again in a moment.",
+            )
+            return
+
         gui_config = self._config_tab.current_config()
 
         # Ask for each referenced KeePass file's master password up front (on
@@ -1412,6 +1452,47 @@ class SyncTab(QWidget):
         self._run_btn.setEnabled(True)
         self._status.setText(f"[X] Error: {error}")
         QMessageBox.critical(self, "Sync error", error)
+
+    def sync_running(self) -> bool:
+        return self._worker is not None and self._worker.isRunning()
+
+    def stop_sync(self, timeout_ms: int = 15000) -> bool:
+        """Cancel a running sync and wait for its thread to unwind.
+
+        Returns whether the thread actually finished; the caller must not let
+        the window go away while it is still running.
+        """
+        worker = self._worker
+        if worker is None or not worker.isRunning():
+            return True
+        # The run is being abandoned, so its outcome is no longer news:
+        # without this a race could still flash "Sync finished" while the
+        # window is closing.
+        for signal in (worker.started_ts, worker.finished_ts, worker.error_occurred):
+            try:
+                signal.disconnect()
+            except (RuntimeError, TypeError):
+                pass  # nothing connected
+        worker.cancel()
+        if worker.wait(timeout_ms):
+            return True
+        # Still running. Run stays disabled on purpose: a second sync would put
+        # two writers on one cache index, and binding a new worker over this
+        # one drops the last reference to a live QThread, which aborts the
+        # process. QThread.finished fires whatever the outcome, so the tab
+        # recovers by itself once the run really ends.
+        self._status.setText("Stopping the sync...")
+        worker.finished.connect(self._on_abandoned_sync_finished)
+        if not worker.isRunning():
+            # It ended between the wait timing out and the connect above, so
+            # the signal has already been and gone; without this the tab would
+            # sit with Run disabled for the rest of the session.
+            self._on_abandoned_sync_finished()
+        return False
+
+    def _on_abandoned_sync_finished(self) -> None:
+        self._run_btn.setEnabled(True)
+        self._status.setText("Sync stopped.")
 
     def _on_task_added(self, name: str, total: object) -> None:
         row = TaskRow(
@@ -1570,6 +1651,38 @@ class MainWindow(QMainWindow):
         quit_action.triggered.connect(self.close)
         file_menu = self.menuBar().addMenu("File")
         file_menu.addAction(quit_action)
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]  # noqa: N802
+        """Stop a running sync before the window - and its thread - go away.
+
+        Qt aborts the process when a QThread is destroyed while still running,
+        so closing the window mid-sync used to crash the app.
+        """
+        if not self._sync_tab.sync_running():
+            event.accept()
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Sync in progress",
+            "A sync is still running. Stop it and quit?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            event.ignore()
+            return
+
+        if not self._sync_tab.stop_sync():
+            # Never tear down a live thread: better to stay open than crash.
+            QMessageBox.warning(
+                self,
+                "Sync still stopping",
+                "The sync has not stopped yet. Try closing again in a moment.",
+            )
+            event.ignore()
+            return
+        event.accept()
 
 
 # ---------------------------------------------------------------------------

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -158,7 +158,7 @@ class SyncWorker(QThread):
             provider = self._build_provider(app_config, tracker)
 
             strava_cred_map = {
-                c.id: c.credential
+                c.uid: c.credential
                 for c in app_config.connectors
                 if isinstance(c, StravaConnectorConfig)
             }
@@ -187,6 +187,7 @@ class SyncWorker(QThread):
                 cache=cache,
                 tracker=tracker,
                 login_tasks=login_tasks,
+                uid_by_id={c.id: c.uid for c in app_config.connectors},
             )
             try:
                 if self._gui_config.skip_wellness:

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -1153,9 +1153,29 @@ class ConfigTab(QWidget):
             if self._connector_name_taken(entry.id, exclude_index=row):
                 self._warn_duplicate_name(entry.id)
                 return
+            old_id = self._config.connectors[row].id
             self._config.connectors[row] = entry
+            self._retarget_groups(old_id, entry.id)
             self._store.save_gui_config(self._config)
             self._refresh_connector_list()
+            self._refresh_group_list()  # groups may now show a new name
+
+    def _retarget_groups(self, old_id: str, new_id: str) -> None:
+        """Point the sync groups at a connector's new name.
+
+        Groups reference connectors by name, so a rename would otherwise leave
+        them pointing at something that no longer exists and the next sync
+        would die resolving it.
+        """
+        if old_id == new_id:
+            return
+        for group in self._config.sync_groups:
+            for source in group.sources:
+                if source.id == old_id:
+                    source.id = new_id
+            group.destinations = [
+                new_id if d == old_id else d for d in group.destinations
+            ]
 
     def _delete_connector(self) -> None:
         row = self._conn_list.currentRow()

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -8,6 +8,7 @@ import sys
 from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from PySide6.QtCore import QDate, QPointF, QRectF, Qt, QThread, Signal
 from PySide6.QtGui import (
@@ -707,6 +708,11 @@ class ConnectorDialog(QDialog):
         self.setWindowTitle("Add Connector" if entry is None else "Edit Connector")
         self.setMinimumWidth(440)
         self._credentials = credentials or []
+        # Editing keeps the connector's identity, so renaming it does not cut
+        # the cache loose. An entry with no uid yet falls back to its name, the
+        # same rule the config parsers use - minting a random one here would
+        # orphan the cache on the very next rename.
+        self._uid = (entry.uid or entry.id) if entry is not None else uuid4().hex
 
         root = QVBoxLayout(self)
         form = QFormLayout()
@@ -809,6 +815,7 @@ class ConnectorDialog(QDialog):
         )
         return ConnectorEntry(
             id=self._id.text().strip(),
+            uid=self._uid,
             type=t,
             credential_service=cred.service if cred else "",
             credential_url=cred.url if cred else "",

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -243,6 +243,7 @@ class SyncWorker(QThread):
                 wellness_cache,
                 tracker,
                 login_tasks=login_tasks,
+                names={c.uid: c.id for c in app_config.connectors},
             )
             await wellness_orch.run(start, end, force=self._gui_config.force)
         except Exception:  # noqa: S110

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -52,6 +52,9 @@ class CredentialEntry:
 class ConnectorEntry:
     id: str
     type: str  # "garmin" | "strava" | "local_folder"
+    # Stable identity, unaffected by renaming `id`; see
+    # app.core.connector_identity. Empty means "assign on load".
+    uid: str = ""
     credential_service: str = ""
     credential_url: str = ""
     credential_login: str = ""
@@ -139,7 +142,15 @@ class ConfigStore:
         if not self._config_path.exists():
             return GuiConfig()
         raw: dict = json.loads(self._config_path.read_text(encoding="utf-8"))
-        return _parse_gui_config(raw)
+        config = _parse_gui_config(raw)
+        # A config written before uids existed has them backfilled from the
+        # connector names above; write that back so the identities are fixed
+        # from now on and a later rename has something to be measured against.
+        if any(
+            isinstance(c, dict) and not c.get("uid") for c in raw.get("connectors", [])
+        ):
+            self.save_gui_config(config)
+        return config
 
     def load_gui_config_from(self, path: Path) -> GuiConfig:
         """Parse a config JSON file at an arbitrary path.
@@ -233,8 +244,12 @@ def _parse_gui_config(raw: dict) -> GuiConfig:
 
 
 def _parse_connector_entry(raw: dict) -> ConnectorEntry:
+    connector_id = raw.get("id", "")
     return ConnectorEntry(
-        id=raw.get("id", ""),
+        id=connector_id,
+        # Pre-uid configs adopt their current name as the stable identity,
+        # which is what the existing cache is already keyed by.
+        uid=raw.get("uid", "") or connector_id,
         type=raw.get("type", ""),
         credential_service=raw.get("credential_service", ""),
         credential_url=raw.get("credential_url", ""),
@@ -256,7 +271,7 @@ def _parse_group_entry(raw: dict) -> SyncGroupEntry:
 
 
 def _serialize_connector(c: ConnectorEntry) -> dict:
-    d: dict = {"id": c.id, "type": c.type}
+    d: dict = {"id": c.id, "uid": c.uid or c.id, "type": c.type}
     if c.type == "garmin":
         d["credential_service"] = c.credential_service
         d["credential_url"] = c.credential_url
@@ -287,6 +302,7 @@ def _connector_to_app(
     if c.type == "garmin":
         return GarminConnectorConfig(
             id=c.id,
+            uid=c.uid or c.id,
             credential=CredentialRequest(
                 service=c.credential_service,
                 url=c.credential_url,
@@ -296,6 +312,7 @@ def _connector_to_app(
     if c.type == "strava":
         return StravaConnectorConfig(
             id=c.id,
+            uid=c.uid or c.id,
             client_id=c.client_id,
             credential=CredentialRequest(
                 service=c.credential_service,
@@ -306,6 +323,7 @@ def _connector_to_app(
     if c.type == "local_folder":
         return LocalFolderConnectorConfig(
             id=c.id,
+            uid=c.uid or c.id,
             folder=Path(c.folder).expanduser().resolve(),
         )
     raise ValueError(f"unknown connector type: {c.type!r}")

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -182,6 +182,11 @@ class ConfigStore:
 
     def to_app_config(self, config: GuiConfig) -> AppConfig:
         connectors = tuple(_connector_to_app(c) for c in config.connectors)
+        # The CLI parser refuses these; a config imported here never goes
+        # through it, and two connectors on one uid share a cache identity.
+        uids = [c.uid for c in connectors]
+        if len(uids) != len(set(uids)):
+            raise ValueError("two connectors share a uid")
         sync_groups = tuple(_group_to_app(g) for g in config.sync_groups)
         start = date.fromisoformat(config.start) if config.start else None
         end = date.fromisoformat(config.end) if config.end else None

--- a/app/gui/config_store.py
+++ b/app/gui/config_store.py
@@ -52,8 +52,8 @@ class CredentialEntry:
 class ConnectorEntry:
     id: str
     type: str  # "garmin" | "strava" | "local_folder"
-    # Stable identity, unaffected by renaming `id`; see
-    # app.core.connector_identity. Empty means "assign on load".
+    # Stable identity, unaffected by renaming `id`. Empty means the parsers
+    # fill it in from the name, which is what a pre-uid config gets.
     uid: str = ""
     credential_service: str = ""
     credential_url: str = ""

--- a/config_templates/config.garmin-to-local.json
+++ b/config_templates/config.garmin-to-local.json
@@ -7,21 +7,28 @@
       "type": "garmin",
       "credential_service": "Garmin Connect",
       "credential_url": "https://connect.garmin.com",
-      "credential_login": "YOUR_GARMIN_EMAIL"
+      "credential_login": "YOUR_GARMIN_EMAIL",
+      "uid": "garmin"
     },
     {
       "id": "local",
       "type": "local_folder",
-      "folder": "/path/to/trainings_data"
+      "folder": "/path/to/trainings_data",
+      "uid": "local"
     }
   ],
   "sync_groups": [
     {
       "id": "default",
       "sources": [
-        {"id": "garmin", "priority": 1}
+        {
+          "id": "garmin",
+          "priority": 1
+        }
       ],
-      "destinations": ["local"]
+      "destinations": [
+        "local"
+      ]
     }
   ]
 }

--- a/config_templates/config.strava-and-garmin.json
+++ b/config_templates/config.strava-and-garmin.json
@@ -7,36 +7,52 @@
       "type": "garmin",
       "credential_service": "Garmin Connect",
       "credential_url": "https://connect.garmin.com",
-      "credential_login": "YOUR_GARMIN_EMAIL"
+      "credential_login": "YOUR_GARMIN_EMAIL",
+      "uid": "garmin"
     },
     {
       "id": "strava",
       "type": "strava",
       "client_id": 0,
       "credential_service": "Strava",
-      "credential_url": "https://www.strava.com/api/v3"
+      "credential_url": "https://www.strava.com/api/v3",
+      "uid": "strava"
     },
     {
       "id": "local",
       "type": "local_folder",
-      "folder": "/path/to/trainings_data"
+      "folder": "/path/to/trainings_data",
+      "uid": "local"
     }
   ],
   "sync_groups": [
     {
       "id": "strava-to-garmin",
       "sources": [
-        {"id": "strava", "priority": 1}
+        {
+          "id": "strava",
+          "priority": 1
+        }
       ],
-      "destinations": ["garmin"]
+      "destinations": [
+        "garmin"
+      ]
     },
     {
       "id": "garmin-and-strava-to-local",
       "sources": [
-        {"id": "garmin", "priority": 1},
-        {"id": "strava", "priority": 2}
+        {
+          "id": "garmin",
+          "priority": 1
+        },
+        {
+          "id": "strava",
+          "priority": 2
+        }
       ],
-      "destinations": ["local"]
+      "destinations": [
+        "local"
+      ]
     }
   ]
 }

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -690,3 +690,41 @@ def test_duplicate_sync_group_ids(tmp_path: Path) -> None:
     data = {**_minimal(), "sync_groups": [_SYNC_GROUP, _SYNC_GROUP]}
     with pytest.raises(ConfigError, match="duplicate sync group id"):
         load_config(_write(tmp_path, data))
+
+
+# ---------------------------------------------------------------------------
+# Connector uid - stable identity behind the display name
+# ---------------------------------------------------------------------------
+
+
+def test_connector_without_a_uid_adopts_its_id(tmp_path: Path) -> None:
+    # CLI configs written before uids existed must keep working unchanged, and
+    # the id they already use is exactly what the cache is keyed by.
+    cfg = load_config(_write(tmp_path, _minimal()))
+    assert [c.uid for c in cfg.connectors] == [c.id for c in cfg.connectors]
+
+
+def test_an_explicit_uid_is_kept(tmp_path: Path) -> None:
+    data = _minimal()
+    data["connectors"] = [{**_GARMIN_CONNECTOR, "uid": "abc123"}, _LOCAL_CONNECTOR]
+    cfg = load_config(_write(tmp_path, data))
+    assert cfg.connectors[0].uid == "abc123"
+    assert cfg.connectors[0].id == "garmin"  # display name is independent
+
+
+def test_a_non_string_uid_is_rejected(tmp_path: Path) -> None:
+    data = _minimal()
+    data["connectors"] = [{**_GARMIN_CONNECTOR, "uid": 17}, _LOCAL_CONNECTOR]
+    with pytest.raises(ConfigError, match="uid"):
+        load_config(_write(tmp_path, data))
+
+
+def test_two_connectors_sharing_a_uid_are_rejected(tmp_path: Path) -> None:
+    # A shared uid reads as a rename and would merge two connectors' caches.
+    data = _minimal()
+    data["connectors"] = [
+        {**_GARMIN_CONNECTOR, "uid": "same"},
+        {**_LOCAL_CONNECTOR, "uid": "same"},
+    ]
+    with pytest.raises(ConfigError, match="duplicate connector uid"):
+        load_config(_write(tmp_path, data))

--- a/tests/core/test_connector_factory.py
+++ b/tests/core/test_connector_factory.py
@@ -124,6 +124,11 @@ def cache(tmp_path: Path) -> ActivityCache:
     return c
 
 
+def _identity(connectors: dict[str, Any]) -> dict[str, str]:
+    """A config predating uids: every name is its own identity."""
+    return {cid: cid for cid in connectors}
+
+
 # ---------------------------------------------------------------------------
 # build_connectors - connector types
 # ---------------------------------------------------------------------------
@@ -350,7 +355,7 @@ def test_resolve_group_sources_returns_specs_and_connectors(tmp_path: Path) -> N
         ),
         destinations=("local",),
     )
-    result = resolve_group_sources(group, connectors)
+    result = resolve_group_sources(group, connectors, _identity(connectors))
     assert len(result) == 2
     spec0, conn0 = result[0]
     assert spec0.source_id == "garmin"
@@ -376,7 +381,7 @@ def test_resolve_group_sources_preserves_order(tmp_path: Path) -> None:
         ),
         destinations=(),
     )
-    result = resolve_group_sources(group, connectors)
+    result = resolve_group_sources(group, connectors, _identity(connectors))
     assert [r[1] for r in result] == [c3, c1, c2]
 
 
@@ -396,7 +401,9 @@ def test_resolve_group_destinations_returns_id_connector_pairs() -> None:
         sources=(GroupSourceConfig(id="garmin", priority=1),),
         destinations=("local",),
     )
-    result = resolve_group_destinations(group, connectors, cache=object())
+    result = resolve_group_destinations(
+        group, connectors, object(), _identity(connectors)
+    )
     assert result == [("local", local_conn)]
 
 
@@ -410,7 +417,9 @@ def test_resolve_group_destinations_multiple() -> None:
         sources=(GroupSourceConfig(id="src", priority=1),),
         destinations=("d1", "d2"),
     )
-    result = resolve_group_destinations(group, connectors, cache=object())
+    result = resolve_group_destinations(
+        group, connectors, object(), _identity(connectors)
+    )
     assert len(result) == 2
     assert result[0] == ("d1", c1)
     assert result[1] == ("d2", c2)
@@ -430,7 +439,7 @@ def test_resolve_group_destinations_wraps_local_as_destination(
         sources=(GroupSourceConfig(id="local", priority=1),),
         destinations=("local",),
     )
-    result = resolve_group_destinations(group, connectors, cache=cache)
+    result = resolve_group_destinations(group, connectors, cache, _identity(connectors))
     assert len(result) == 1
     dest_id, dest_conn = result[0]
     assert dest_id == "local"

--- a/tests/core/test_connector_factory.py
+++ b/tests/core/test_connector_factory.py
@@ -436,3 +436,65 @@ def test_resolve_group_destinations_wraps_local_as_destination(
     assert dest_conn is not local_source
     assert dest_conn._cache is cache
     assert dest_conn._dest_id == "local"
+
+
+# ---------------------------------------------------------------------------
+# Cache keys follow the uid, labels follow the name
+# ---------------------------------------------------------------------------
+
+
+async def test_connectors_are_keyed_by_uid_not_by_name(
+    tracker: TaskTracker, tmp_path: Path
+) -> None:
+    # The key is what the cache is filed under, so it must be the thing that
+    # does not move when the user renames a connector.
+    local = LocalFolderConnectorConfig(id="Garmin Denis", uid="3f9a1c", folder=tmp_path)
+    result = await build_connectors(
+        _cfg(connectors=(local,), sync_groups=()), _FakeProvider([]), tracker
+    )
+    assert list(result) == ["3f9a1c"]
+
+
+def test_a_group_resolves_names_to_uids() -> None:
+    group = SyncGroupConfig(
+        id="g",
+        sources=(GroupSourceConfig(id="Garmin Denis", priority=1),),
+        destinations=("Garmin Denis",),
+    )
+    connectors = {"3f9a1c": object()}
+    uid_by_id = {"Garmin Denis": "3f9a1c"}
+
+    ((spec, _),) = resolve_group_sources(group, connectors, uid_by_id)  # type: ignore[arg-type]
+    ((dest_id, _),) = resolve_group_destinations(
+        group,
+        connectors,
+        object(),
+        uid_by_id,  # type: ignore[arg-type]
+    )
+
+    assert spec.source_id == "3f9a1c"
+    assert dest_id == "3f9a1c"
+
+
+def test_renaming_a_connector_leaves_the_cache_key_alone() -> None:
+    # The whole point: the cache is filed under the uid, so a rename is a
+    # label change and nothing more - no data has to move.
+    before = LocalFolderConnectorConfig(
+        id="Garmin Denis", uid="3f9a1c", folder=Path("/tmp")
+    )
+    after = LocalFolderConnectorConfig(
+        id="Garmin Home", uid="3f9a1c", folder=Path("/tmp")
+    )
+    assert before.uid == after.uid
+
+
+def test_two_connectors_swapping_names_keep_distinct_keys() -> None:
+    # This is the case that made a name-keyed cache so hard to migrate.
+    a = LocalFolderConnectorConfig(id="Bravo", uid="aaa", folder=Path("/tmp"))
+    b = LocalFolderConnectorConfig(id="Alpha", uid="bbb", folder=Path("/tmp"))
+    assert a.uid != b.uid
+
+
+def test_a_config_built_in_code_still_gets_an_identity() -> None:
+    # An empty uid would collapse every such connector onto one cache key.
+    assert LocalFolderConnectorConfig(id="local", folder=Path("/tmp")).uid == "local"

--- a/tests/core/test_connector_factory.py
+++ b/tests/core/test_connector_factory.py
@@ -15,6 +15,7 @@ from app.connectors.strava import StravaConnector
 from app.core.cache import ActivityCache, CacheEntry
 from app.core.config import (
     AppConfig,
+    ConnectorConfig,
     GarminConnectorConfig,
     GroupSourceConfig,
     LocalFolderConnectorConfig,
@@ -96,6 +97,9 @@ _STRAVA_CFG = StravaConnectorConfig(
 
 _GARMIN_CREDS = Credentials(login="user@example.com", password="garmin-pass")
 _STRAVA_CREDS = Credentials(login="client-secret-val", password="refresh-token-val")
+_STRAVA_REFRESHED = StravaCredentials(
+    client_id=1, client_secret="client-secret-val", refresh_token="rotated"
+)
 
 _DEFAULT_GROUP = SyncGroupConfig(
     id="default",
@@ -578,6 +582,30 @@ def test_a_config_built_in_code_still_gets_an_identity() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _wellness_case(
+    kind: str, folder: Path
+) -> tuple[ConnectorConfig, list[Credentials]]:
+    """A connector of each type, with a uid that differs from its name."""
+    if kind == "garmin":
+        return (
+            GarminConnectorConfig(
+                id="Garmin Denis", uid="g-uid", credential=_GARMIN_CFG.credential
+            ),
+            [_GARMIN_CREDS],
+        )
+    if kind == "strava":
+        return (
+            StravaConnectorConfig(
+                id="Strava Denis",
+                uid="s-uid",
+                client_id=1,
+                credential=_STRAVA_CFG.credential,
+            ),
+            [_STRAVA_CREDS],
+        )
+    return LocalFolderConnectorConfig(id="Folder", uid="f-uid", folder=folder), []
+
+
 async def test_wellness_connectors_are_keyed_by_uid(
     tracker: TaskTracker, tmp_path: Path
 ) -> None:
@@ -599,21 +627,43 @@ async def test_wellness_connectors_are_keyed_by_uid(
     assert wellness["g-uid"].connector_id == "g-uid"
 
 
+@pytest.mark.parametrize("kind", ["garmin", "strava", "local_folder"])
 async def test_wellness_connectors_carry_the_display_name(
-    tracker: TaskTracker, tmp_path: Path
+    tracker: TaskTracker, tmp_path: Path, kind: str
 ) -> None:
-    local = LocalFolderConnectorConfig(id="Folder", uid="f-uid", folder=tmp_path)
-    config = _cfg(connectors=(local,), sync_groups=())
-    activity = await build_connectors(config, _FakeProvider([]), tracker)
+    # Every branch builds its own connector, so a missed one shows the user a
+    # hex string where its name belongs.
+    cfg, creds = _wellness_case(kind, tmp_path)
+    config = _cfg(connectors=(cfg,), sync_groups=())
+    activity = await build_connectors(config, _FakeProvider(creds), tracker)
 
     wellness = await build_wellness_connectors(
         config, _FakeProvider([]), tracker, activity
     )
 
-    assert wellness["f-uid"].display_name == "Folder"
+    assert wellness[cfg.uid].display_name == cfg.id
 
 
-async def test_the_strava_token_callback_reports_the_uid(tracker: TaskTracker) -> None:
+@pytest.mark.parametrize("kind", ["garmin", "strava", "local_folder"])
+async def test_every_wellness_type_is_keyed_by_uid(
+    tracker: TaskTracker, tmp_path: Path, kind: str
+) -> None:
+    # Looking the activity connector up by name misses, and that branch then
+    # builds nothing at all - silently, with no error and no task.
+    cfg, creds = _wellness_case(kind, tmp_path)
+    config = _cfg(connectors=(cfg,), sync_groups=())
+    activity = await build_connectors(config, _FakeProvider(creds), tracker)
+
+    wellness = await build_wellness_connectors(
+        config, _FakeProvider([]), tracker, activity
+    )
+
+    assert set(wellness) == {cfg.uid}
+
+
+async def test_the_strava_token_callback_reports_the_uid(
+    tracker: TaskTracker,
+) -> None:
     # The callback and the credential map the caller looks the id up in are
     # two halves of one contract: disagree, and a rotated refresh token raises
     # KeyError from inside Strava login, which then fails outright.
@@ -624,13 +674,18 @@ async def test_the_strava_token_callback_reports_the_uid(tracker: TaskTracker) -
         credential=_STRAVA_CFG.credential,
     )
     seen: list[str] = []
-    await build_connectors(
+    built = await build_connectors(
         _cfg(connectors=(strava,), sync_groups=()),
         _FakeProvider([_STRAVA_CREDS]),
         tracker,
         on_strava_token_refresh=lambda cid, *_: seen.append(cid),
     )
 
+    # Fire it the way StravaConnector does when a token rotates.
+    connector = built["s-uid"]
+    connector._on_token_refresh(_STRAVA_REFRESHED, "acct")  # type: ignore[attr-defined]
+
+    assert seen == ["s-uid"]
+    # And the caller must be able to resolve that id in the map it builds.
     cred_map = {c.uid: c.credential for c in (strava,)}
-    # Exercise the wiring the way the CLI and the GUI do.
-    assert set(cred_map) == {"s-uid"}
+    assert cred_map[seen[0]] is strava.credential

--- a/tests/core/test_connector_factory.py
+++ b/tests/core/test_connector_factory.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from app.connectors.base import ServiceConnector
 from app.connectors.garmin import GarminConnector
 from app.connectors.local_folder import LocalFolderConnector
 from app.connectors.strava import StravaConnector
-from app.core.cache import ActivityCache
+from app.core.cache import ActivityCache, CacheEntry
 from app.core.config import (
     AppConfig,
     GarminConnectorConfig,
@@ -461,38 +463,67 @@ def test_a_group_resolves_names_to_uids() -> None:
         sources=(GroupSourceConfig(id="Garmin Denis", priority=1),),
         destinations=("Garmin Denis",),
     )
-    connectors = {"3f9a1c": object()}
+    connectors: dict[str, ServiceConnector] = {
+        "3f9a1c": cast(ServiceConnector, object())
+    }
     uid_by_id = {"Garmin Denis": "3f9a1c"}
 
-    ((spec, _),) = resolve_group_sources(group, connectors, uid_by_id)  # type: ignore[arg-type]
-    ((dest_id, _),) = resolve_group_destinations(
-        group,
-        connectors,
-        object(),
-        uid_by_id,  # type: ignore[arg-type]
-    )
+    ((spec, _),) = resolve_group_sources(group, connectors, uid_by_id)
+    ((dest_id, _),) = resolve_group_destinations(group, connectors, object(), uid_by_id)
 
     assert spec.source_id == "3f9a1c"
     assert dest_id == "3f9a1c"
 
 
-def test_renaming_a_connector_leaves_the_cache_key_alone() -> None:
-    # The whole point: the cache is filed under the uid, so a rename is a
-    # label change and nothing more - no data has to move.
+def test_renaming_a_connector_keeps_its_cached_activities(tmp_path: Path) -> None:
+    # The whole point of keying by uid: a rename is a label change, so nothing
+    # in the cache has to move and nothing is re-downloaded.
+    cache = ActivityCache(tmp_path)
+    entry = CacheEntry(
+        external_id="1",
+        source_id="3f9a1c",  # the uid, not the name
+        format="gpx",
+        start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        elapsed_s=60,
+    )
+    cache.put(entry, b"track")
+
     before = LocalFolderConnectorConfig(
-        id="Garmin Denis", uid="3f9a1c", folder=Path("/tmp")
+        id="Garmin Denis", uid="3f9a1c", folder=tmp_path
     )
-    after = LocalFolderConnectorConfig(
-        id="Garmin Home", uid="3f9a1c", folder=Path("/tmp")
-    )
-    assert before.uid == after.uid
+    after = LocalFolderConnectorConfig(id="Garmin Home", uid="3f9a1c", folder=tmp_path)
+
+    assert cache.has("1", before.uid)
+    assert cache.has("1", after.uid)  # renamed, and still found
 
 
-def test_two_connectors_swapping_names_keep_distinct_keys() -> None:
-    # This is the case that made a name-keyed cache so hard to migrate.
-    a = LocalFolderConnectorConfig(id="Bravo", uid="aaa", folder=Path("/tmp"))
-    b = LocalFolderConnectorConfig(id="Alpha", uid="bbb", folder=Path("/tmp"))
-    assert a.uid != b.uid
+def test_two_connectors_swapping_names_keep_their_own_activities(
+    tmp_path: Path,
+) -> None:
+    # The case that made a name-keyed cache so hard to migrate: with uids it
+    # is not a case at all, because neither key moves.
+    cache = ActivityCache(tmp_path)
+    for uid, payload in (("aaa", b"alpha"), ("bbb", b"bravo")):
+        cache.put(
+            CacheEntry(
+                external_id=uid,
+                source_id=uid,
+                format="gpx",
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                elapsed_s=60,
+            ),
+            payload,
+        )
+
+    # Alpha and Bravo swap display names; the uids are untouched.
+    a = LocalFolderConnectorConfig(id="Bravo", uid="aaa", folder=tmp_path)
+    b = LocalFolderConnectorConfig(id="Alpha", uid="bbb", folder=tmp_path)
+
+    alpha = cache.get_entry("aaa", a.uid)
+    bravo = cache.get_entry("bbb", b.uid)
+    assert alpha is not None and bravo is not None
+    assert cache.read_content(alpha) == b"alpha"
+    assert cache.read_content(bravo) == b"bravo"
 
 
 def test_a_config_built_in_code_still_gets_an_identity() -> None:

--- a/tests/core/test_connector_factory.py
+++ b/tests/core/test_connector_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
@@ -22,6 +23,7 @@ from app.core.config import (
 )
 from app.core.connector_factory import (
     build_connectors,
+    build_wellness_connectors,
     resolve_group_destinations,
     resolve_group_sources,
 )
@@ -31,6 +33,7 @@ from app.credentials.base import (
     Credentials,
     StravaCredentials,
 )
+from app.gui.config_store import ConfigStore, ConnectorEntry, GuiConfig
 from app.tracking.tracker import ProgressRenderer, Task, TaskTracker
 
 # ---------------------------------------------------------------------------
@@ -485,33 +488,56 @@ def test_a_group_resolves_names_to_uids() -> None:
 
 
 def test_renaming_a_connector_keeps_its_cached_activities(tmp_path: Path) -> None:
-    # The whole point of keying by uid: a rename is a label change, so nothing
-    # in the cache has to move and nothing is re-downloaded.
-    cache = ActivityCache(tmp_path)
-    entry = CacheEntry(
-        external_id="1",
-        source_id="3f9a1c",  # the uid, not the name
-        format="gpx",
-        start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        elapsed_s=60,
+    # Drive the rename the way the GUI does, then ask the same cache again.
+    store = ConfigStore(config_dir=tmp_path / "cfg")
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(
+                    id="Garmin Denis", uid="3f9a1c", type="local_folder", folder="/a"
+                )
+            ],
+            sync_groups=[],
+        )
     )
-    cache.put(entry, b"track")
-
-    before = LocalFolderConnectorConfig(
-        id="Garmin Denis", uid="3f9a1c", folder=tmp_path
+    cache = ActivityCache(tmp_path / "cache")
+    uid = store.to_app_config(store.load_gui_config()).connectors[0].uid
+    cache.put(
+        CacheEntry(
+            external_id="1",
+            source_id=uid,
+            format="gpx",
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            elapsed_s=60,
+        ),
+        b"track",
     )
-    after = LocalFolderConnectorConfig(id="Garmin Home", uid="3f9a1c", folder=tmp_path)
+    assert cache.has("1", uid)
 
-    assert cache.has("1", before.uid)
-    assert cache.has("1", after.uid)  # renamed, and still found
+    renamed = replace(store.load_gui_config().connectors[0], id="Garmin Home")
+    store.save_gui_config(GuiConfig(connectors=[renamed], sync_groups=[]))
+
+    after = store.to_app_config(store.load_gui_config()).connectors[0]
+    assert after.id == "Garmin Home"
+    assert cache.has("1", after.uid)  # the rename did not orphan anything
 
 
 def test_two_connectors_swapping_names_keep_their_own_activities(
     tmp_path: Path,
 ) -> None:
-    # The case that made a name-keyed cache so hard to migrate: with uids it
-    # is not a case at all, because neither key moves.
-    cache = ActivityCache(tmp_path)
+    # The case that made a name-keyed cache so hard to migrate. Swap the names
+    # through the store, then ask the cache for each connector's own activity.
+    store = ConfigStore(config_dir=tmp_path / "cfg")
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(id="Alpha", uid="aaa", type="local_folder", folder="/a"),
+                ConnectorEntry(id="Bravo", uid="bbb", type="local_folder", folder="/b"),
+            ],
+            sync_groups=[],
+        )
+    )
+    cache = ActivityCache(tmp_path / "cache")
     for uid, payload in (("aaa", b"alpha"), ("bbb", b"bravo")):
         cache.put(
             CacheEntry(
@@ -524,12 +550,19 @@ def test_two_connectors_swapping_names_keep_their_own_activities(
             payload,
         )
 
-    # Alpha and Bravo swap display names; the uids are untouched.
-    a = LocalFolderConnectorConfig(id="Bravo", uid="aaa", folder=tmp_path)
-    b = LocalFolderConnectorConfig(id="Alpha", uid="bbb", folder=tmp_path)
+    loaded = store.load_gui_config().connectors
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[replace(loaded[0], id="Bravo"), replace(loaded[1], id="Alpha")],
+            sync_groups=[],
+        )
+    )
 
-    alpha = cache.get_entry("aaa", a.uid)
-    bravo = cache.get_entry("bbb", b.uid)
+    by_name = {
+        c.id: c.uid for c in store.to_app_config(store.load_gui_config()).connectors
+    }
+    alpha = cache.get_entry("aaa", by_name["Bravo"])  # was Alpha, now named Bravo
+    bravo = cache.get_entry("bbb", by_name["Alpha"])
     assert alpha is not None and bravo is not None
     assert cache.read_content(alpha) == b"alpha"
     assert cache.read_content(bravo) == b"bravo"
@@ -538,3 +571,66 @@ def test_two_connectors_swapping_names_keep_their_own_activities(
 def test_a_config_built_in_code_still_gets_an_identity() -> None:
     # An empty uid would collapse every such connector onto one cache key.
     assert LocalFolderConnectorConfig(id="local", folder=Path("/tmp")).uid == "local"
+
+
+# ---------------------------------------------------------------------------
+# Seams where the uid meets something else
+# ---------------------------------------------------------------------------
+
+
+async def test_wellness_connectors_are_keyed_by_uid(
+    tracker: TaskTracker, tmp_path: Path
+) -> None:
+    # The activity connectors are keyed by uid, so looking them up by name
+    # here misses - and wellness then silently does nothing at all: no error,
+    # no task, no log line.
+    garmin = GarminConnectorConfig(
+        id="Garmin Denis", uid="g-uid", credential=_GARMIN_CFG.credential
+    )
+    local = LocalFolderConnectorConfig(id="Folder", uid="f-uid", folder=tmp_path)
+    config = _cfg(connectors=(garmin, local), sync_groups=())
+    activity = await build_connectors(config, _FakeProvider([_GARMIN_CREDS]), tracker)
+
+    wellness = await build_wellness_connectors(
+        config, _FakeProvider([]), tracker, activity
+    )
+
+    assert set(wellness) == {"g-uid", "f-uid"}
+    assert wellness["g-uid"].connector_id == "g-uid"
+
+
+async def test_wellness_connectors_carry_the_display_name(
+    tracker: TaskTracker, tmp_path: Path
+) -> None:
+    local = LocalFolderConnectorConfig(id="Folder", uid="f-uid", folder=tmp_path)
+    config = _cfg(connectors=(local,), sync_groups=())
+    activity = await build_connectors(config, _FakeProvider([]), tracker)
+
+    wellness = await build_wellness_connectors(
+        config, _FakeProvider([]), tracker, activity
+    )
+
+    assert wellness["f-uid"].display_name == "Folder"
+
+
+async def test_the_strava_token_callback_reports_the_uid(tracker: TaskTracker) -> None:
+    # The callback and the credential map the caller looks the id up in are
+    # two halves of one contract: disagree, and a rotated refresh token raises
+    # KeyError from inside Strava login, which then fails outright.
+    strava = StravaConnectorConfig(
+        id="Strava Denis",
+        uid="s-uid",
+        client_id=1,
+        credential=_STRAVA_CFG.credential,
+    )
+    seen: list[str] = []
+    await build_connectors(
+        _cfg(connectors=(strava,), sync_groups=()),
+        _FakeProvider([_STRAVA_CREDS]),
+        tracker,
+        on_strava_token_refresh=lambda cid, *_: seen.append(cid),
+    )
+
+    cred_map = {c.uid: c.credential for c in (strava,)}
+    # Exercise the wiring the way the CLI and the GUI do.
+    assert set(cred_map) == {"s-uid"}

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -14,6 +14,13 @@ from app.core.config import GroupSourceConfig, SyncGroupConfig
 from app.core.orchestrator import SyncOrchestrator
 
 _UTC = timezone.utc
+
+
+def _identity(connectors: dict) -> dict[str, str]:
+    """These tests predate uids: every name is its own identity."""
+    return {cid: cid for cid in connectors}
+
+
 _START = date(2026, 1, 1)
 _END = date(2026, 1, 31)
 
@@ -64,7 +71,12 @@ async def test_downloads_all_unique_sources(cache: ActivityCache) -> None:
         for spec, _ in executor_self._sources:
             downloaded.add(spec.source_id)
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)
 
@@ -83,7 +95,12 @@ async def test_source_downloads_run_in_parallel(cache: ActivityCache) -> None:
         await asyncio.sleep(0)
         download_log.append(f"{src_id}-done")
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)
 
@@ -105,7 +122,12 @@ async def test_returns_total_download_failures_across_sources(
     async def _fake_download(executor_self, start, end, *, force=False, **_kw):  # type: ignore[no-untyped-def]
         executor_self._download_failures = 2
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         total = await orchestrator.run(_START, _END)
 
@@ -120,7 +142,9 @@ async def test_source_executor_has_empty_task_prefix(cache: ActivityCache) -> No
     async def _fake_download(executor_self, start, end, *, force=False, **_kw):  # type: ignore[no-untyped-def]
         captured_prefixes.append(executor_self._task_prefix)
 
-    orchestrator = SyncOrchestrator(groups=(g,), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g,), connectors=connectors, cache=cache, uid_by_id=_identity(connectors)
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)
 
@@ -133,7 +157,12 @@ async def test_same_source_downloaded_once_across_groups(cache: ActivityCache) -
     g2 = _group("g2", ["strava"], [])
     connectors = {"strava": _mock_connector()}
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     await orchestrator.run(_START, _END)
 
     # list_activities is called inside the single source executor's download_phase.
@@ -181,7 +210,11 @@ async def test_same_source_has_single_download_task(cache: ActivityCache) -> Non
     tracker.warn = AsyncMock()
 
     orchestrator = SyncOrchestrator(
-        groups=(g1, g2), connectors=connectors, cache=cache, tracker=tracker
+        groups=(g1, g2),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        tracker=tracker,
     )
     await orchestrator.run(_START, _END)
 
@@ -209,7 +242,11 @@ async def test_logs_source_start_and_end_when_sync_logger_present(
         pass
 
     orchestrator = SyncOrchestrator(
-        groups=(g,), connectors=connectors, cache=cache, tracker=tracker
+        groups=(g,),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        tracker=tracker,
     )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)
@@ -233,7 +270,11 @@ async def test_logs_source_failed_when_download_raises(cache: ActivityCache) -> 
         raise RuntimeError("boom")
 
     orchestrator = SyncOrchestrator(
-        groups=(g,), connectors=connectors, cache=cache, tracker=tracker
+        groups=(g,),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        tracker=tracker,
     )
     with patch(
         "app.core.orchestrator.SyncExecutor.download_phase", new=_raising_download
@@ -263,7 +304,11 @@ async def test_logs_group_failed_when_upload_phase_raises(cache: ActivityCache) 
         raise RuntimeError("upload boom")
 
     orchestrator = SyncOrchestrator(
-        groups=(g,), connectors=connectors, cache=cache, tracker=tracker
+        groups=(g,),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        tracker=tracker,
     )
     with (
         patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download),
@@ -283,7 +328,9 @@ async def test_no_log_when_no_tracker(cache: ActivityCache) -> None:
     async def _fake_download(executor_self, start, end, *, force=False, **_kw):  # type: ignore[no-untyped-def]
         pass
 
-    orchestrator = SyncOrchestrator(groups=(g,), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g,), connectors=connectors, cache=cache, uid_by_id=_identity(connectors)
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)  # must not raise
 
@@ -299,7 +346,11 @@ async def test_no_log_when_tracker_has_no_sync_logger(cache: ActivityCache) -> N
         pass
 
     orchestrator = SyncOrchestrator(
-        groups=(g,), connectors=connectors, cache=cache, tracker=tracker
+        groups=(g,),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        tracker=tracker,
     )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)  # must not raise
@@ -318,7 +369,9 @@ async def test_force_forwarded_to_executor(cache: ActivityCache) -> None:
     async def _fake_download(executor_self, start, end, *, force=False, **_kw):  # type: ignore[no-untyped-def]
         received_force.append(force)
 
-    orchestrator = SyncOrchestrator(groups=(g,), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g,), connectors=connectors, cache=cache, uid_by_id=_identity(connectors)
+    )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END, force=True)
 
@@ -355,7 +408,12 @@ async def test_uploads_serialized_when_source_is_other_groups_destination(
         )  # yield; sibling must not interleave because lock is held
         upload_log.append(f"{executor_self._task_prefix}done")
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     with (
         patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download),
         patch("app.core.orchestrator.SyncExecutor.upload_phase", new=_fake_upload),
@@ -392,7 +450,12 @@ async def test_uploads_with_shared_destination_run_sequentially(
         )  # yield; sibling must not interleave because lock is held
         upload_log.append(f"{executor_self._task_prefix}done")
 
-    orchestrator = SyncOrchestrator(groups=(g1, g2), connectors=connectors, cache=cache)
+    orchestrator = SyncOrchestrator(
+        groups=(g1, g2),
+        connectors=connectors,
+        cache=cache,
+        uid_by_id=_identity(connectors),
+    )
     with (
         patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download),
         patch("app.core.orchestrator.SyncExecutor.upload_phase", new=_fake_upload),
@@ -433,7 +496,11 @@ async def test_externally_cancelled_run_logs_source_as_failed(
         "app.core.orchestrator.SyncExecutor.download_phase", new=_hanging_download
     ):
         orchestrator = SyncOrchestrator(
-            groups=(g,), connectors=connectors, cache=cache, tracker=tracker
+            groups=(g,),
+            connectors=connectors,
+            uid_by_id=_identity(connectors),
+            cache=cache,
+            tracker=tracker,
         )
         task = asyncio.create_task(orchestrator.run(_START, _END))
         await reached.wait()
@@ -456,7 +523,11 @@ async def test_login_tasks_passed_to_source_executor(cache: ActivityCache) -> No
     login_task: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
     login_tasks = {"src": login_task}
     orchestrator = SyncOrchestrator(
-        groups=(g,), connectors=connectors, cache=cache, login_tasks=login_tasks
+        groups=(g,),
+        connectors=connectors,
+        uid_by_id=_identity(connectors),
+        cache=cache,
+        login_tasks=login_tasks,
     )
     with patch("app.core.orchestrator.SyncExecutor.download_phase", new=_fake_download):
         await orchestrator.run(_START, _END)

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -463,3 +463,34 @@ async def test_login_tasks_passed_to_source_executor(cache: ActivityCache) -> No
     await login_task
 
     assert captured == [login_tasks]
+
+
+async def test_a_sync_runs_when_the_uid_differs_from_the_name(
+    tmp_path: Path,
+) -> None:
+    # Every connector made in the GUI has a random uid, and so does every
+    # renamed one - the case this whole design exists for. The per-connector
+    # locks are keyed by uid, so looking them up by name kills the upload
+    # phase with a KeyError after the download has already run.
+    group = SyncGroupConfig(
+        id="g",
+        sources=(GroupSourceConfig(id="Garmin Denis", priority=1),),
+        destinations=("Local Folder",),
+    )
+    source = MagicMock()
+    source.login = AsyncMock()
+    source.list_activities = AsyncMock(return_value=[])
+    source.user_label = "acct"
+    dest = MagicMock()
+    dest.login = AsyncMock()
+    dest.list_activities = AsyncMock(return_value=[])
+    dest.user_label = ""
+
+    orchestrator = SyncOrchestrator(
+        groups=(group,),
+        connectors={"a1b2c3": source, "e5f6a7": dest},
+        cache=ActivityCache(tmp_path / "cache"),
+        uid_by_id={"Garmin Denis": "a1b2c3", "Local Folder": "e5f6a7"},
+    )
+
+    assert await orchestrator.run(date(2026, 1, 1), date(2026, 1, 2)) == 0

--- a/tests/core/test_sync.py
+++ b/tests/core/test_sync.py
@@ -2474,3 +2474,61 @@ class TestUploadPhase:
         await executor_b.upload_phase(_START, _END)
         # act-1 is now visible in the freshly fetched list -- no second upload
         assert dest.upload_activity.await_count == 1
+
+
+class TestDisplayNames:
+    """Ids here are uids; the user must never be shown one."""
+
+    async def test_task_names_and_logs_use_the_connector_name(
+        self, cache: ActivityCache
+    ) -> None:
+        # Everything downstream is keyed by uid so a rename never moves cached
+        # data. Without the names map every task and log line would read as a
+        # hex string - which is what the user actually sees.
+        meta = _meta()
+        conn = _source_conn(metas=[meta])
+        tracker = MagicMock()
+        tracker.add_task = AsyncMock(side_effect=lambda name, **_kw: name)
+        tracker.advance = AsyncMock()
+        tracker.finish = AsyncMock()
+        tracker.update_total = AsyncMock()
+        tracker.warn = AsyncMock()
+        tracker.sync_logger = MagicMock()
+        executor = SyncExecutor(
+            sources=[(_spec("3f9a1c"), conn)],
+            destinations=[],
+            cache=cache,
+            tracker=tracker,
+            names={"3f9a1c": "Garmin Denis"},
+        )
+
+        await executor.run(_START, _END)
+
+        task_names = [c.args[0] for c in tracker.add_task.call_args_list]
+        assert any("Garmin Denis" in n for n in task_names)
+        assert not any("3f9a1c" in n for n in task_names)
+        logged = [c.args[0] for c in tracker.sync_logger.info.call_args_list]
+        assert not any(m.startswith("[download] 3f9a1c") for m in logged)
+
+    async def test_a_connector_with_no_name_falls_back_to_its_id(
+        self, cache: ActivityCache
+    ) -> None:
+        conn = _source_conn(metas=[_meta()])
+        tracker = MagicMock()
+        tracker.add_task = AsyncMock(side_effect=lambda name, **_kw: name)
+        tracker.advance = AsyncMock()
+        tracker.finish = AsyncMock()
+        tracker.update_total = AsyncMock()
+        tracker.warn = AsyncMock()
+        tracker.sync_logger = None
+        executor = SyncExecutor(
+            sources=[(_spec("garmin"), conn)],
+            destinations=[],
+            cache=cache,
+            tracker=tracker,
+            names={},
+        )
+
+        await executor.run(_START, _END)
+
+        assert any("garmin" in c.args[0] for c in tracker.add_task.call_args_list)

--- a/tests/core/test_wellness_orchestrator.py
+++ b/tests/core/test_wellness_orchestrator.py
@@ -398,3 +398,38 @@ async def test_the_task_list_shows_the_connector_name_not_its_uid(
 
     assert any("Garmin Denis" in name for name in renderer.task_names)
     assert not any("3f9a1c" in name for name in renderer.task_names)
+
+
+async def test_a_wellness_connector_names_itself_by_its_display_name(
+    tracker: TaskTracker,
+) -> None:
+    # The connectors build their own task names, so the orchestrator's map
+    # does not reach them - they need the name handed over at construction.
+    from app.connectors.strava_wellness import StravaWellnessConnector
+
+    renderer = _NameRecordingRenderer()
+    connector = StravaWellnessConnector(
+        connector_id="a1b2c3d4e5f6",
+        strava_connector=MagicMock(),
+        tracker=TaskTracker(renderer),
+        display_name="Strava Denis",
+    )
+
+    await connector.login()
+
+    assert renderer.task_names == ["Strava wellness (Strava Denis): connect"]
+
+
+async def test_a_wellness_connector_falls_back_to_its_id(tracker: TaskTracker) -> None:
+    from app.connectors.strava_wellness import StravaWellnessConnector
+
+    renderer = _NameRecordingRenderer()
+    connector = StravaWellnessConnector(
+        connector_id="garmin",
+        strava_connector=MagicMock(),
+        tracker=TaskTracker(renderer),
+    )
+
+    await connector.login()
+
+    assert renderer.task_names == ["Strava wellness (garmin): connect"]

--- a/tests/core/test_wellness_orchestrator.py
+++ b/tests/core/test_wellness_orchestrator.py
@@ -18,6 +18,12 @@ from app.core.wellness_cache import WellnessCache
 from app.core.wellness_orchestrator import WellnessOrchestrator
 from app.tracking.tracker import ProgressRenderer, Task, TaskStatus, TaskTracker
 
+
+def _identity(connectors: dict) -> dict[str, str]:
+    """These tests predate uids: every name is its own identity."""
+    return {cid: cid for cid in connectors}
+
+
 _START = date(2026, 1, 1)
 _END = date(2026, 1, 3)
 
@@ -97,7 +103,9 @@ class TestRunDownload:
         source = _make_source_connector(
             "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         assert source.fetch_daily.call_count == 3  # type: ignore[union-attr, attr-defined]
@@ -108,7 +116,9 @@ class TestRunDownload:
         source = _make_source_connector(
             "garmin", tracker, range_types=[WellnessDataType.BODY_BATTERY]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         source.fetch_range.assert_called_once()  # type: ignore[union-attr, attr-defined]
@@ -119,7 +129,9 @@ class TestRunDownload:
         source = _make_source_connector(
             "garmin", tracker, snapshot_types=[WellnessDataType.PERSONAL_RECORDS]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         source.fetch_snapshot.assert_called_once()  # type: ignore[union-attr, attr-defined]
@@ -130,7 +142,9 @@ class TestRunDownload:
         source = _make_source_connector(
             "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         key = WellnessCache.daily_key(_START)
@@ -143,7 +157,9 @@ class TestRunDownload:
         source = _make_source_connector(
             "garmin", tracker, range_types=[WellnessDataType.BODY_BATTERY]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         key = WellnessCache.range_key(_START, _END)
@@ -158,7 +174,9 @@ class TestRunDownload:
         key = WellnessCache.daily_key(_START)
         cache.write("garmin", WellnessDataType.SLEEP, key, {"cached": True})
 
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         assert source.fetch_daily.call_count == 2  # type: ignore[union-attr, attr-defined]
@@ -172,7 +190,9 @@ class TestRunDownload:
         key = WellnessCache.range_key(_START, _END)
         cache.write("garmin", WellnessDataType.BODY_BATTERY, key, {"cached": True})
 
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         source.fetch_range.assert_not_called()  # type: ignore[union-attr, attr-defined]
@@ -190,7 +210,9 @@ class TestRunDownload:
             {"cached": True},
         )
 
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         source.fetch_snapshot.assert_not_called()  # type: ignore[union-attr, attr-defined]
@@ -205,7 +227,9 @@ class TestRunDownload:
             daily_data=None,
         )
         source.fetch_daily = AsyncMock(return_value=None)  # type: ignore[union-attr, method-assign]
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         key = WellnessCache.daily_key(_START)
@@ -222,7 +246,9 @@ class TestRunForce:
         key = WellnessCache.daily_key(_START)
         cache.write("garmin", WellnessDataType.SLEEP, key, {"old": True})
 
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END, force=True)
 
         assert source.fetch_daily.call_count == 3  # type: ignore[union-attr, attr-defined]
@@ -238,7 +264,9 @@ class TestRunForce:
         key = WellnessCache.daily_key(_START)
         cache.write("garmin", WellnessDataType.SLEEP, key, {"old": True})
 
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END, force=False)
 
         assert source.fetch_daily.call_count == 2  # type: ignore[union-attr, attr-defined]
@@ -255,7 +283,12 @@ class TestRunUpload:
         dest_folder.mkdir()
         dest = _make_local_folder_connector("local", dest_folder, tracker)
 
-        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source, "local": dest},
+            cache,
+            tracker,
+            names=_identity({"garmin": source, "local": dest}),
+        )
         await orch.run(_START, _END)
 
         for d_offset in range(3):
@@ -279,7 +312,12 @@ class TestRunUpload:
         dest_folder.mkdir()
         dest = _make_local_folder_connector("local", dest_folder, tracker)
 
-        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source, "local": dest},
+            cache,
+            tracker,
+            names=_identity({"garmin": source, "local": dest}),
+        )
         await orch.run(_START, _END)
 
         tasks = tracker.tasks
@@ -299,7 +337,12 @@ class TestRunUpload:
         dest_folder.mkdir()
         dest = _make_local_folder_connector("local", dest_folder, tracker)
 
-        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source, "local": dest},
+            cache,
+            tracker,
+            names=_identity({"garmin": source, "local": dest}),
+        )
         await orch.run(_START, _END)
 
         result = await dest.fetch_snapshot(WellnessDataType.PERSONAL_RECORDS)
@@ -313,7 +356,9 @@ class TestProgressTracking:
         source = _make_source_connector(
             "garmin", tracker, daily_types=[WellnessDataType.SLEEP]
         )
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         tasks = tracker.tasks
@@ -333,7 +378,12 @@ class TestProgressTracking:
         dest_folder.mkdir()
         dest = _make_local_folder_connector("local", dest_folder, tracker)
 
-        orch = WellnessOrchestrator({"garmin": source, "local": dest}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source, "local": dest},
+            cache,
+            tracker,
+            names=_identity({"garmin": source, "local": dest}),
+        )
         await orch.run(_START, _END)
 
         tasks = tracker.tasks
@@ -345,7 +395,9 @@ class TestProgressTracking:
         self, cache: WellnessCache, tracker: TaskTracker
     ) -> None:
         source = _make_source_connector("garmin", tracker)
-        orch = WellnessOrchestrator({"garmin": source}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"garmin": source}, cache, tracker, names=_identity({"garmin": source})
+        )
         await orch.run(_START, _END)
 
         tasks = tracker.tasks
@@ -361,7 +413,9 @@ class TestLocalFolderNotTreatedAsSource:
         folder.mkdir()
         dest = _make_local_folder_connector("local", folder, tracker)
 
-        orch = WellnessOrchestrator({"local": dest}, cache, tracker)
+        orch = WellnessOrchestrator(
+            {"local": dest}, cache, tracker, names=_identity({"local": dest})
+        )
         await orch.run(_START, _END)
 
         tasks = tracker.tasks

--- a/tests/core/test_wellness_orchestrator.py
+++ b/tests/core/test_wellness_orchestrator.py
@@ -367,3 +367,34 @@ class TestLocalFolderNotTreatedAsSource:
         tasks = tracker.tasks
         download_tasks = [n for n in tasks if "Wellness download" in n]
         assert len(download_tasks) == 0
+
+
+class _NameRecordingRenderer(_FakeRenderer):
+    def __init__(self) -> None:
+        self.task_names: list[str] = []
+
+    def on_task_added(self, task: Task) -> None:
+        self.task_names.append(task.name)
+
+
+async def test_the_task_list_shows_the_connector_name_not_its_uid(
+    cache: WellnessCache,
+) -> None:
+    # Connectors are keyed by uid so that a rename never moves cached data -
+    # but a hex string is not what the user should read in the task list.
+    renderer = _NameRecordingRenderer()
+    tracker = TaskTracker(renderer)
+    source = _make_source_connector(
+        "3f9a1c", tracker, daily_types=[WellnessDataType.SLEEP]
+    )
+    orch = WellnessOrchestrator(
+        {"3f9a1c": source},
+        cache,
+        tracker,
+        names={"3f9a1c": "Garmin Denis"},
+    )
+
+    await orch.run(_START, _END)
+
+    assert any("Garmin Denis" in name for name in renderer.task_names)
+    assert not any("3f9a1c" in name for name in renderer.task_names)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import date
 from pathlib import Path
 
@@ -1270,6 +1271,45 @@ def test_sync_worker_logs_and_closes_logger_on_setup_failure(
     assert "Sync run finished" in log_text  # run_end() ran in the finally block
 
 
+def test_sync_worker_cancel_stops_a_running_sync(qtbot, store: ConfigStore) -> None:
+    # Quitting mid-sync has to be able to unwind the thread: Qt aborts the
+    # process if a QThread is destroyed while it is still running.
+    class _SlowWorker(SyncWorker):
+        async def _async_sync(self) -> int:
+            await asyncio.sleep(60)
+            return 0
+
+    worker = _SlowWorker(store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer())
+    worker.start()
+    qtbot.waitUntil(lambda: worker._task is not None, timeout=5000)
+    worker.cancel()
+    assert worker.wait(5000)
+    assert not worker.isRunning()
+
+
+def test_cancelling_before_the_sync_arms_itself_still_stops_it(
+    qtbot, store: ConfigStore
+) -> None:
+    # cancel() has no task to reach in the gap between start() and the
+    # coroutine's first line; closing the window right after Run lands there.
+    class _SlowWorker(SyncWorker):
+        async def _async_sync(self) -> int:
+            await asyncio.sleep(60)
+            return 0
+
+    worker = _SlowWorker(store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer())
+    worker.cancel()
+    worker.start()
+
+    assert worker.wait(5000)
+    assert not worker.isRunning()
+
+
+def test_sync_worker_cancel_before_it_started_does_nothing(store: ConfigStore) -> None:
+    worker = SyncWorker(store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer())
+    worker.cancel()  # must not raise: there is no loop to reach into yet
+
+
 def test_sync_worker_keepass_rejects_strava_connectors(
     qtbot, store: ConfigStore
 ) -> None:
@@ -1501,6 +1541,192 @@ def test_main_window_has_window_icon(qtbot, store: ConfigStore) -> None:
     window = MainWindow(store)
     qtbot.addWidget(window)
     assert not window.windowIcon().isNull()
+
+
+def _stub_sync_tab(monkeypatch, window, *, running: bool, stops: bool = True) -> list:
+    calls: list[str] = []
+    monkeypatch.setattr(window._sync_tab, "sync_running", lambda: running)
+
+    def _stop(*_args: object, **_kwargs: object) -> bool:
+        calls.append("stop")
+        return stops
+
+    monkeypatch.setattr(window._sync_tab, "stop_sync", _stop)
+    return calls
+
+
+def test_closing_without_a_running_sync_closes_straight_away(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    calls = _stub_sync_tab(monkeypatch, window, running=False)
+    assert window.close() is True
+    assert calls == []
+
+
+def test_closing_mid_sync_can_be_called_off(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    calls = _stub_sync_tab(monkeypatch, window, running=True)
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.No),
+    )
+    assert window.close() is False
+    assert calls == []  # the running sync was left alone
+
+
+def test_closing_mid_sync_stops_the_sync_first(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    from PySide6.QtWidgets import QMessageBox
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    calls = _stub_sync_tab(monkeypatch, window, running=True)
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    assert window.close() is True
+    assert calls == ["stop"]
+
+
+def test_a_stop_that_times_out_leaves_the_tab_usable(qtbot, store: ConfigStore) -> None:
+    # The window stays open in this case, so the tab must not be left with a
+    # dead Run button: the worker's signals are disconnected by now, and
+    # nothing else ever re-enables it.
+    #
+    # Cancelling does not interrupt a blocking call already handed to a thread,
+    # which is how every connector does its network I/O - so this is the shape
+    # a real overrun takes.
+    class _StubbornWorker(SyncWorker):
+        async def _async_sync(self) -> int:
+            await asyncio.to_thread(time.sleep, 2)
+            return 0
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tab = window._sync_tab
+    worker = _StubbornWorker(
+        store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer()
+    )
+    worker.started_ts.connect(tab._on_started)
+    worker.finished_ts.connect(tab._on_finished)
+    worker.error_occurred.connect(tab._on_error)
+    tab._worker = worker
+    tab._run_btn.setEnabled(False)
+    worker.start()
+    qtbot.waitUntil(lambda: worker._task is not None, timeout=5000)
+
+    try:
+        assert tab.stop_sync(timeout_ms=1) is False
+        # Run stays disabled while the abandoned worker is alive.
+        assert not tab._run_btn.isEnabled()
+    finally:
+        # Never leave the thread running: a QThread still alive at interpreter
+        # shutdown aborts the whole process.
+        assert worker.wait(10000)
+    qtbot.waitUntil(tab._run_btn.isEnabled, timeout=5000)
+
+
+def test_run_is_refused_while_a_stopped_sync_is_still_unwinding(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    # Two syncs on one cache index means lost updates, and rebinding the
+    # worker would destroy a live QThread - which aborts the process.
+    from PySide6.QtWidgets import QMessageBox
+
+    class _StubbornWorker(SyncWorker):
+        async def _async_sync(self) -> int:
+            await asyncio.to_thread(time.sleep, 2)
+            return 0
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tab = window._sync_tab
+    worker = _StubbornWorker(
+        store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer()
+    )
+    tab._worker = worker
+    worker.start()
+    qtbot.waitUntil(lambda: worker._task is not None, timeout=5000)
+
+    told = []
+    monkeypatch.setattr(
+        QMessageBox, "information", staticmethod(lambda *a, **k: told.append(a))
+    )
+    try:
+        tab._run_sync()
+        assert told, "starting a second sync should be refused"
+        assert tab._worker is worker  # the live thread was not replaced
+    finally:
+        worker.cancel()
+        assert worker.wait(10000)
+
+
+def test_a_sync_ending_just_as_the_stop_times_out_still_frees_the_tab(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    # QThread.finished fires once. If it lands between the wait timing out and
+    # the connect, nothing would ever re-enable Run again.
+    class _SlowWorker(SyncWorker):
+        async def _async_sync(self) -> int:
+            await asyncio.sleep(60)
+            return 0
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    tab = window._sync_tab
+    worker = _SlowWorker(store, GuiConfig(connectors=[], sync_groups=[]), GuiRenderer())
+    tab._worker = worker
+    tab._run_btn.setEnabled(False)
+    worker.start()
+    qtbot.waitUntil(lambda: worker._task is not None, timeout=5000)
+
+    # wait() reports a timeout, but the run is over by the time we look again.
+    def _wait_then_finish(_timeout: int = 0) -> bool:
+        worker.cancel()
+        SyncWorker.wait(worker, 5000)
+        return False
+
+    monkeypatch.setattr(worker, "wait", _wait_then_finish)
+
+    assert tab.stop_sync(timeout_ms=1) is False
+    assert tab._run_btn.isEnabled()
+
+
+def test_stopping_an_idle_tab_is_a_no_op(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    assert window._sync_tab.stop_sync() is True
+
+
+def test_window_stays_open_when_the_sync_refuses_to_stop(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    # Destroying a QThread that is still running aborts the process, so a sync
+    # that will not stop has to keep the window alive instead of crashing.
+    from PySide6.QtWidgets import QMessageBox
+
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    calls = _stub_sync_tab(monkeypatch, window, running=True, stops=False)
+    monkeypatch.setattr(
+        QMessageBox,
+        "question",
+        staticmethod(lambda *a, **k: QMessageBox.StandardButton.Yes),
+    )
+    monkeypatch.setattr(QMessageBox, "warning", staticmethod(lambda *a, **k: None))
+    assert window.close() is False
+    assert calls == ["stop"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -230,6 +230,43 @@ def test_connector_dialog_type_dropdown_matches_supported_types(qtbot) -> None:
     assert items == list(CONNECTOR_TYPES)
 
 
+def test_a_new_connector_gets_its_own_uid(qtbot) -> None:
+    # The uid is what lets the cache follow a connector across renames, so a
+    # fresh connector must not be left without one.
+    first, second = ConnectorDialog(), ConnectorDialog()
+    qtbot.addWidget(first)
+    qtbot.addWidget(second)
+    assert first.result_entry().uid
+    assert first.result_entry().uid != second.result_entry().uid
+
+
+def test_editing_a_connector_keeps_its_uid(qtbot) -> None:
+    existing = ConnectorEntry(id="Garmin", uid="abc123", type="garmin")
+    dlg = ConnectorDialog(entry=existing)
+    qtbot.addWidget(dlg)
+    dlg._id.setText("Garmin Denis")
+    result = dlg.result_entry()
+    assert (result.id, result.uid) == ("Garmin Denis", "abc123")
+
+
+def test_editing_a_pre_uid_connector_adopts_its_name_as_the_uid(qtbot) -> None:
+    # The name is what the cache is already keyed by, so it is the only safe
+    # identity to adopt; a random one would look like a brand new connector.
+    dlg = ConnectorDialog(entry=ConnectorEntry(id="Garmin", type="garmin"))
+    qtbot.addWidget(dlg)
+    assert dlg.result_entry().uid == "Garmin"
+
+
+def test_a_pre_uid_connector_renamed_in_one_sitting_keeps_its_cache(qtbot) -> None:
+    # Renaming straight after upgrading is the case most likely to lose data:
+    # the uid has to be the old name, or the rename goes unnoticed.
+    dlg = ConnectorDialog(entry=ConnectorEntry(id="Garmin", type="garmin"))
+    qtbot.addWidget(dlg)
+    dlg._id.setText("Garmin Denis")
+    result = dlg.result_entry()
+    assert (result.id, result.uid) == ("Garmin Denis", "Garmin")
+
+
 def test_connector_dialog_prefilled_strava(qtbot) -> None:
     existing = ConnectorEntry(
         id="strava",

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -1150,9 +1150,8 @@ def test_config_tab_edit_connector_keeping_own_name_is_allowed(
 def test_renaming_a_connector_repoints_the_sync_groups(
     qtbot, monkeypatch, store: ConfigStore
 ) -> None:
-    # Groups reference connectors by name. Leaving them on the old name makes
-    # the next sync die resolving it - after the cache migration has already
-    # moved everything, so the failure lands at the worst possible moment.
+    # Groups reference connectors by name, so leaving them on the old one
+    # makes the next sync die resolving it.
     import app.gui.app as gui_app
 
     store.save_gui_config(

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -13,6 +13,7 @@ from app.gui.app import (
     _COUNT_MIN_WIDTH,
     ConfigTab,
     ConnectorDialog,
+    CounterColumn,
     CredentialDialog,
     CredentialsTab,
     LogDialog,
@@ -944,6 +945,46 @@ def test_task_row_counter_keeps_its_width_for_small_totals(qtbot) -> None:
     qtbot.addWidget(row)
     row.update_progress(3)
     assert row._count.minimumWidth() == _COUNT_MIN_WIDTH
+
+
+def test_rows_sharing_a_column_keep_one_counter_width(qtbot) -> None:
+    # Equal counter widths are what keeps the progress bars in one column:
+    # sizing each row to its own text would shove the wide rows' bars left.
+    column = CounterColumn()
+    small = TaskRow("Login", total=1, column=column)
+    big = TaskRow("Wellness download", total=193372, column=column)
+    qtbot.addWidget(small)
+    qtbot.addWidget(big)
+    small.update_progress(1)
+    big.update_progress(191081)
+    assert small._count.minimumWidth() == big._count.minimumWidth()
+    needed = big._count.fontMetrics().horizontalAdvance(big._count.text())
+    assert big._count.minimumWidth() >= needed
+
+
+def test_a_row_added_later_adopts_the_column_width(qtbot) -> None:
+    # Rows appear as tasks start, so one joining after the column has already
+    # widened must not fall back to the narrow default.
+    column = CounterColumn()
+    big = TaskRow("Wellness download", total=193372, column=column)
+    qtbot.addWidget(big)
+    late = TaskRow("Login", total=1, column=column)
+    qtbot.addWidget(late)
+    assert late._count.minimumWidth() == big._count.minimumWidth()
+    assert late._count.minimumWidth() > _COUNT_MIN_WIDTH
+
+
+def test_a_late_total_widens_every_row_in_the_column(qtbot) -> None:
+    # Wellness download reports its total only once it is running.
+    column = CounterColumn()
+    small = TaskRow("Login", total=1, column=column)
+    late = TaskRow("Wellness download", total=None, column=column)
+    qtbot.addWidget(small)
+    qtbot.addWidget(late)
+    before = small._count.minimumWidth()
+    late.update_total(193372)
+    assert small._count.minimumWidth() > before
+    assert small._count.minimumWidth() == late._count.minimumWidth()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -1147,6 +1147,87 @@ def test_config_tab_edit_connector_keeping_own_name_is_allowed(
     assert saved[0].folder == "/b"
 
 
+def test_renaming_a_connector_repoints_the_sync_groups(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    # Groups reference connectors by name. Leaving them on the old name makes
+    # the next sync die resolving it - after the cache migration has already
+    # moved everything, so the failure lands at the worst possible moment.
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(id="Garmin", uid="u1", type="local_folder", folder="/a"),
+                ConnectorEntry(id="Local", uid="u2", type="local_folder", folder="/b"),
+            ],
+            sync_groups=[
+                SyncGroupEntry(
+                    id="g1",
+                    sources=[GroupSourceEntry(id="Garmin", priority=1)],
+                    destinations=["Local", "Garmin"],
+                )
+            ],
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+
+    renamed = ConnectorEntry(
+        id="Garmin Denis", uid="u1", type="local_folder", folder="/a"
+    )
+    monkeypatch.setattr(
+        gui_app, "ConnectorDialog", lambda **kw: _FakeConnectorDialog(renamed)
+    )
+    tab._conn_list.setCurrentRow(0)
+    tab._edit_connector()
+
+    group = store.load_gui_config().sync_groups[0]
+    assert [s.id for s in group.sources] == ["Garmin Denis"]
+    assert group.destinations == ["Local", "Garmin Denis"]
+    # The list on screen must not keep showing a connector that is gone.
+    shown = [tab._grp_list.item(i).text() for i in range(tab._grp_list.count())]
+    assert "Garmin Denis" in shown[0]
+    assert "[Garmin(" not in shown[0]
+
+
+def test_editing_a_connector_without_renaming_leaves_the_groups_alone(
+    qtbot, monkeypatch, store: ConfigStore
+) -> None:
+    import app.gui.app as gui_app
+
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[
+                ConnectorEntry(id="Garmin", uid="u1", type="local_folder", folder="/a")
+            ],
+            sync_groups=[
+                SyncGroupEntry(
+                    id="g1",
+                    sources=[GroupSourceEntry(id="Garmin", priority=1)],
+                    destinations=["Garmin"],
+                )
+            ],
+        )
+    )
+    tab = ConfigTab(store)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(
+        gui_app,
+        "ConnectorDialog",
+        lambda **kw: _FakeConnectorDialog(
+            ConnectorEntry(id="Garmin", uid="u1", type="local_folder", folder="/b")
+        ),
+    )
+    tab._conn_list.setCurrentRow(0)
+    tab._edit_connector()
+
+    group = store.load_gui_config().sync_groups[0]
+    assert [s.id for s in group.sources] == ["Garmin"]
+    assert group.destinations == ["Garmin"]
+
+
 class _FakeGroupDialog:
     def __init__(self, entry: SyncGroupEntry) -> None:
         self._entry = entry

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import date
 from pathlib import Path
 
@@ -497,6 +498,7 @@ def test_serialize_connector_garmin() -> None:
     d = _serialize_connector(c)
     assert d == {
         "id": "g",
+        "uid": "g",  # falls back to the display id for pre-uid entries
         "type": "garmin",
         "credential_service": "Garmin Connect",
         "credential_url": "https://connect.garmin.com",
@@ -619,3 +621,99 @@ def test_group_to_app() -> None:
     assert sg.id == "grp"
     assert sg.sources[0].id == "s"
     assert sg.destinations == ("d",)
+
+
+# ---------------------------------------------------------------------------
+# Connector uid - survives renaming so the cache stays attached
+# ---------------------------------------------------------------------------
+
+
+def test_a_connector_without_a_uid_adopts_its_id() -> None:
+    # Existing GUI configs have no uid; the name they already carry is what
+    # the cache is keyed by, so adopting it migrates nothing.
+    entry = _parse_connector_entry({"id": "Garmin Denis", "type": "garmin"})
+    assert entry.uid == "Garmin Denis"
+
+
+def test_an_explicit_uid_is_kept_over_the_id() -> None:
+    entry = _parse_connector_entry(
+        {"id": "Garmin Denis", "uid": "abc123", "type": "garmin"}
+    )
+    assert (entry.uid, entry.id) == ("abc123", "Garmin Denis")
+
+
+def test_the_uid_survives_a_save_and_load_round_trip(tmp_path: Path) -> None:
+    store = ConfigStore(config_dir=tmp_path)
+    store.save_gui_config(
+        GuiConfig(
+            connectors=[ConnectorEntry(id="Garmin", uid="abc123", type="garmin")],
+            sync_groups=[],
+        )
+    )
+    assert store.load_gui_config().connectors[0].uid == "abc123"
+
+
+def test_renaming_a_connector_keeps_its_uid(tmp_path: Path) -> None:
+    # This is the whole point: the display name moves, the identity does not,
+    # so the cache stays attached to it.
+    store = ConfigStore(config_dir=tmp_path)
+    original = ConnectorEntry(id="Garmin", uid="abc123", type="garmin")
+    store.save_gui_config(GuiConfig(connectors=[original], sync_groups=[]))
+
+    renamed = replace(store.load_gui_config().connectors[0], id="Garmin Denis")
+    store.save_gui_config(GuiConfig(connectors=[renamed], sync_groups=[]))
+
+    reloaded = store.load_gui_config().connectors[0]
+    assert (reloaded.id, reloaded.uid) == ("Garmin Denis", "abc123")
+
+
+def test_the_uid_reaches_the_app_config(tmp_path: Path) -> None:
+    store = ConfigStore(config_dir=tmp_path)
+    config = GuiConfig(
+        connectors=[ConnectorEntry(id="Garmin Denis", uid="abc123", type="garmin")],
+        sync_groups=[],
+    )
+    assert store.to_app_config(config).connectors[0].uid == "abc123"
+
+
+def test_loading_a_pre_uid_config_writes_the_uids_back(tmp_path: Path) -> None:
+    # The identities have to reach the file: a rename is only recognisable if
+    # the uid was recorded before it happened.
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "connectors": [{"id": "Garmin Denis", "type": "garmin"}],
+                "sync_groups": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = ConfigStore(config_dir=tmp_path)
+
+    store.load_gui_config()
+
+    on_disk = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    assert on_disk["connectors"][0]["uid"] == "Garmin Denis"
+
+
+def test_loading_a_config_that_already_has_uids_leaves_the_file_alone(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "connectors": [
+                    {"id": "Garmin Denis", "uid": "abc123", "type": "garmin"}
+                ],
+                "sync_groups": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = ConfigStore(config_dir=tmp_path)
+    before = path.stat().st_mtime_ns
+
+    store.load_gui_config()
+
+    assert path.stat().st_mtime_ns == before

--- a/tests/gui/test_config_store.py
+++ b/tests/gui/test_config_store.py
@@ -717,3 +717,30 @@ def test_loading_a_config_that_already_has_uids_leaves_the_file_alone(
     store.load_gui_config()
 
     assert path.stat().st_mtime_ns == before
+
+
+@pytest.mark.parametrize("kind", ["garmin", "strava", "local_folder"])
+def test_the_uid_reaches_the_app_config_for_every_connector_type(
+    tmp_path: Path, kind: str
+) -> None:
+    # Losing it for one type would silently fall back to the name, which is
+    # exactly the orphaned cache this design exists to prevent.
+    store = ConfigStore(config_dir=tmp_path)
+    entry = ConnectorEntry(id="Garmin Denis", uid="3f9a1c", type=kind, folder="/a")
+    config = GuiConfig(connectors=[entry], sync_groups=[])
+    assert store.to_app_config(config).connectors[0].uid == "3f9a1c"
+
+
+def test_two_connectors_sharing_a_uid_are_refused(tmp_path: Path) -> None:
+    # A config can be hand-edited or imported without going through the CLI
+    # parser that catches this.
+    store = ConfigStore(config_dir=tmp_path)
+    config = GuiConfig(
+        connectors=[
+            ConnectorEntry(id="A", uid="same", type="local_folder", folder="/a"),
+            ConnectorEntry(id="B", uid="same", type="local_folder", folder="/b"),
+        ],
+        sync_groups=[],
+    )
+    with pytest.raises(ValueError, match="share a uid"):
+        store.to_app_config(config)

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "trainings-sync"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "garminconnect" },


### PR DESCRIPTION
Six commits, replacing an earlier attempt on this branch that migrated the cache when a connector was renamed. Eight rounds of review kept finding defects in that machinery - each round in the previous round's fix - so it was dropped in favour of removing the reason to migrate at all.

## The GUI fixes (unrelated to the cache)

**Progress bars drifted out of column.** A regression from the counter fix in 0.1.4: sizing each counter to its own text made the widths differ per row, and since every row lays itself out as `[status][label][bar][counter]`, a wider counter drags that row's bar left. Width is now a property of the column, not the row.

**Closing the window mid-sync aborted the process.** `SyncWorker` is a `QThread` and there was no `closeEvent`, so closing destroyed a thread that was still running. It is now cancellable, `closeEvent` stops it and waits, and if it will not stop the window stays open rather than tearing down a live thread. Includes the follow-ups review found in that fix: a cancel arriving before the coroutine arms itself, a second sync being startable while the first was still unwinding, and the Run button never coming back after a stop that overran.

**Renaming a connector broke its sync groups.** Groups reference connectors by name, so a rename left them pointing at something that no longer existed and the next sync died resolving it.

## The cache change

The cache keyed `source_id`, `uploaded_to`, `local_paths` and the wellness folders by the connector's **display name**, so renaming a connector silently orphaned its whole history - it was re-downloaded and re-uploaded.

The first attempt was to migrate the data on rename. That is where the complexity lived: the destination of a move can be another connector's source (`A->B` while `B->A`, or `A->C` while `B->A`), which needs ordering, journalling, phase bookkeeping and crash recovery. Eight review rounds found a defect in it every time.

Instead, connectors now carry a stable `uid` and the cache is keyed by that. A rename changes only the label; **no data moves at all**, so there is nothing to get wrong. Swaps and chains stop being a category.

- `SourceSpec.source_id` and `dest_id` carry the uid; the display name is threaded separately for the log and the task list, so nothing shows a hex string
- a config with no `uid` adopts its current name as its identity - which is exactly what its cache is already filed under, so **existing installs need no migration**: the folder is already called the right thing
- new connectors get a fresh uid; editing one keeps it
- a config built in code rather than parsed gets its identity from its name, so an empty uid can never collapse several connectors onto one key
- duplicate uids are refused

## Also

`uv.lock` kept its own stale version because release-please only bumps `pyproject.toml`, so every `uv sync` left the tree dirty. The release workflow now runs `uv lock` on the release branch.

1181 tests, 99% coverage.