### PR TITLE
fix: show the app under its real name in the dock and fix the bundle metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ env:
   # switcher and the menu bar - none of which ever look at the window title,
   # so leaving it as APP_NAME showed the app as "trainings-sync".
   APP_DISPLAY_NAME: Trainings Sync
+  # Reverse-DNS bundle id. macOS keys preferences, granted folder permissions
+  # and LaunchServices registration off this, so every app needs its own.
+  APP_BUNDLE_ID: io.github.dchernykh1984.trainings-sync
 
 jobs:
   targets:
@@ -68,6 +71,8 @@ jobs:
 
       - name: Build portable app
         shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           # Pin PyInstaller so a future major release cannot break builds.
@@ -78,7 +83,22 @@ jobs:
             # bundle carries the display name while the zip around it keeps
             # the artifact name.
             "${pyi[@]}" --name "$APP_DISPLAY_NAME" --icon app/app.icns \
+              --osx-bundle-identifier "$APP_BUNDLE_ID" \
               "${common[@]}" app/gui/app.py
+            # PyInstaller hardcodes CFBundleShortVersionString to 0.0.0 and
+            # offers no flag for it, so stamp the plist by hand. On a release
+            # the tag is authoritative; on a smoke build fall back to
+            # pyproject.toml.
+            version="${RELEASE_TAG#v}"
+            if [ -z "$version" ]; then
+              version=$(awk -F'"' '/^version *= *"/ {print $2; exit}' pyproject.toml)
+            fi
+            plist="dist/${APP_DISPLAY_NAME}.app/Contents/Info.plist"
+            plutil -replace CFBundleShortVersionString -string "$version" "$plist"
+            plutil -replace CFBundleVersion -string "$version" "$plist"
+            # Editing the plist breaks the ad-hoc signature PyInstaller
+            # applied ("plist or signature have been modified"), so reseal it.
+            codesign --force --sign - "dist/${APP_DISPLAY_NAME}.app"
             ( cd dist && zip -r -y "${APP_NAME}-${{ matrix.name }}.zip" \
               "${APP_DISPLAY_NAME}.app" )
             echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.zip" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,13 @@ on:
         default: ""
 
 env:
+  # File name: the artifacts and the frozen executable. Kept ASCII and
+  # space-free so a download URL stays readable.
   APP_NAME: trainings-sync
+  # User-facing name. macOS reads it from the bundle for the dock, the task
+  # switcher and the menu bar - none of which ever look at the window title,
+  # so leaving it as APP_NAME showed the app as "trainings-sync".
+  APP_DISPLAY_NAME: Trainings Sync
 
 jobs:
   targets:
@@ -66,17 +72,23 @@ jobs:
           set -euo pipefail
           # Pin PyInstaller so a future major release cannot break builds.
           pyi=(uv run --with "pyinstaller>=6,<7" pyinstaller)
-          common=(--noconfirm --windowed --name "$APP_NAME" --collect-submodules app)
+          common=(--noconfirm --windowed --collect-submodules app)
           if [ "$RUNNER_OS" = "macOS" ]; then
-            "${pyi[@]}" --icon app/app.icns "${common[@]}" app/gui/app.py
-            ( cd dist && zip -r -y "${APP_NAME}-${{ matrix.name }}.zip" "${APP_NAME}.app" )
+            # --name drives every name in the bundle's Info.plist, so the
+            # bundle carries the display name while the zip around it keeps
+            # the artifact name.
+            "${pyi[@]}" --name "$APP_DISPLAY_NAME" --icon app/app.icns \
+              "${common[@]}" app/gui/app.py
+            ( cd dist && zip -r -y "${APP_NAME}-${{ matrix.name }}.zip" \
+              "${APP_DISPLAY_NAME}.app" )
             echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.zip" >> "$GITHUB_ENV"
           elif [ "$RUNNER_OS" = "Windows" ]; then
-            "${pyi[@]}" --onefile --icon app/app.ico "${common[@]}" app/gui/app.py
+            "${pyi[@]}" --name "$APP_NAME" --onefile --icon app/app.ico \
+              "${common[@]}" app/gui/app.py
             mv "dist/${APP_NAME}.exe" "dist/${APP_NAME}-${{ matrix.name }}.exe"
             echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.exe" >> "$GITHUB_ENV"
           else
-            "${pyi[@]}" --onefile "${common[@]}" app/gui/app.py
+            "${pyi[@]}" --name "$APP_NAME" --onefile "${common[@]}" app/gui/app.py
             mv "dist/${APP_NAME}" "dist/${APP_NAME}-${{ matrix.name }}"
             echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}" >> "$GITHUB_ENV"
           fi

--- a/app/gui/app.py
+++ b/app/gui/app.py
@@ -73,6 +73,14 @@ from app.gui.config_store import (
 )
 from app.tracking.gui_renderer import GuiRenderer
 
+# How the app calls itself to the user and to the OS shell. The macOS dock and
+# task switcher read this from the frozen bundle's Info.plist (see the build
+# workflow), never from the window title - the two are kept in step by hand.
+APP_DISPLAY_NAME = "Trainings Sync"
+# Basename of the freedesktop .desktop entry; on Linux it becomes the window's
+# WM_CLASS, which is what the taskbar labels the window with.
+APP_DESKTOP_NAME = "trainings-sync"
+
 # ---------------------------------------------------------------------------
 # SyncWorker - runs the full sync pipeline in a background QThread
 # ---------------------------------------------------------------------------
@@ -1654,7 +1662,7 @@ def make_app_icon(size: int = 256) -> QIcon:
 class MainWindow(QMainWindow):
     def __init__(self, store: ConfigStore) -> None:
         super().__init__()
-        self.setWindowTitle("Trainings Sync")
+        self.setWindowTitle(APP_DISPLAY_NAME)
         self.setWindowIcon(make_app_icon())
         # Wide enough that the Sync tab's task rows (long connector labels plus a
         # fixed-width progress bar and counter) fit without a horizontal scroll.
@@ -1719,8 +1727,21 @@ class MainWindow(QMainWindow):
 # ---------------------------------------------------------------------------
 
 
+def configure_app_identity(app: QApplication) -> None:
+    """Tell the OS shell what this app is called.
+
+    Without this the name defaults to the basename of argv[0] - the artifact
+    file name, suffixed with the platform - so the Linux taskbar labels the
+    window ``trainings-sync-linux-x86_64``.
+    """
+    app.setApplicationName(APP_DISPLAY_NAME)
+    app.setApplicationDisplayName(APP_DISPLAY_NAME)
+    app.setDesktopFileName(APP_DESKTOP_NAME)
+
+
 def main() -> None:
     app = QApplication(sys.argv)
+    configure_app_identity(app)
     app.setWindowIcon(make_app_icon())
     store = ConfigStore()
     window = MainWindow(store)

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -12,6 +12,8 @@ from PySide6.QtCore import Qt
 
 from app.gui.app import (
     _COUNT_MIN_WIDTH,
+    APP_DESKTOP_NAME,
+    APP_DISPLAY_NAME,
     ConfigTab,
     ConnectorDialog,
     CounterColumn,
@@ -23,6 +25,7 @@ from app.gui.app import (
     SyncWorker,
     TaskRow,
     _parse_date_or_default,
+    configure_app_identity,
     make_app_icon,
 )
 from app.gui.config_store import (
@@ -1658,6 +1661,41 @@ def test_main_window_has_window_icon(qtbot, store: ConfigStore) -> None:
     window = MainWindow(store)
     qtbot.addWidget(window)
     assert not window.windowIcon().isNull()
+
+
+def test_main_window_title_is_the_display_name(qtbot, store: ConfigStore) -> None:
+    window = MainWindow(store)
+    qtbot.addWidget(window)
+    assert window.windowTitle() == APP_DISPLAY_NAME
+
+
+# ---------------------------------------------------------------------------
+# Application identity
+# ---------------------------------------------------------------------------
+
+
+def test_configure_app_identity_names_the_app_for_the_shell(qapp) -> None:
+    before = (
+        qapp.applicationName(),
+        qapp.applicationDisplayName(),
+        qapp.desktopFileName(),
+    )
+    try:
+        configure_app_identity(qapp)
+        assert qapp.applicationName() == APP_DISPLAY_NAME
+        assert qapp.applicationDisplayName() == APP_DISPLAY_NAME
+        assert qapp.desktopFileName() == APP_DESKTOP_NAME
+    finally:
+        qapp.setApplicationName(before[0])
+        qapp.setApplicationDisplayName(before[1])
+        qapp.setDesktopFileName(before[2])
+
+
+def test_display_name_is_not_the_artifact_name() -> None:
+    # The regression this guards: the shell name fell back to the packaged
+    # file name, so the dock read "trainings-sync".
+    assert APP_DISPLAY_NAME != APP_DESKTOP_NAME
+    assert "-" not in APP_DISPLAY_NAME
 
 
 def _stub_sync_tab(monkeypatch, window, *, running: bool, stops: bool = True) -> list:

--- a/tests/gui/test_build_workflow.py
+++ b/tests/gui/test_build_workflow.py
@@ -1,0 +1,26 @@
+"""The build workflow and the app must agree on what the app is called.
+
+Nothing else ties the two together: the workflow stamps the name into the
+macOS bundle, the app sets the same name on the Qt application, and a rename
+on one side alone is exactly how the dock ended up showing "trainings-sync".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.gui.app import APP_DISPLAY_NAME
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "build.yml"
+
+
+def _workflow_env(name: str) -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(rf"^  {re.escape(name)}: *(\S.*?) *$", text, re.MULTILINE)
+    assert match is not None, f"{name} is not set in {WORKFLOW.name}"
+    return match.group(1)
+
+
+def test_workflow_display_name_matches_the_app() -> None:
+    assert _workflow_env("APP_DISPLAY_NAME") == APP_DISPLAY_NAME

--- a/tests/gui/test_build_workflow.py
+++ b/tests/gui/test_build_workflow.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 from app.gui.app import APP_DISPLAY_NAME
 
-WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "build.yml"
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "build.yml"
 
 
 def _workflow_env(name: str) -> str:
@@ -22,5 +23,21 @@ def _workflow_env(name: str) -> str:
     return match.group(1)
 
 
+def _project_name() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^name *= *"(.+?)"', text, re.MULTILINE)
+    assert match is not None, "pyproject.toml has no project name"
+    return match.group(1)
+
+
 def test_workflow_display_name_matches_the_app() -> None:
     assert _workflow_env("APP_DISPLAY_NAME") == APP_DISPLAY_NAME
+
+
+def test_workflow_bundle_id_is_reverse_dns_for_this_project() -> None:
+    # Copied between six sibling repos, so pin it to this project's own name -
+    # a bundle id left pointing at a sibling would silently make macOS treat
+    # the two apps as one.
+    bundle_id = _workflow_env("APP_BUNDLE_ID")
+    assert re.fullmatch(r"[a-z0-9]+(\.[a-z0-9-]+)+", bundle_id), bundle_id
+    assert bundle_id.rsplit(".", 1)[-1] == _project_name()


### PR DESCRIPTION
## Проблема

В Dock, Cmd-Tab и строке меню приложение показывалось как `trainings-sync`.

macOS берёт это имя из `Info.plist` бандла и **никогда** не смотрит на заголовок окна. В workflow флаг `--name` получал `APP_NAME` — имя файла артефакта, — и оно уезжало разом во все ключи plist.

Попутно там же обнаружилось:
- `CFBundleIdentifier: trainings-sync` вместо reverse-DNS — macOS привязывает к нему настройки, выданные разрешения и регистрацию в LaunchServices;
- `CFBundleShortVersionString: 0.0.0` — версия из release-please до бандла не доезжала.

## Коммит 1 — имя

- в workflow разведены `APP_NAME` (имя файла и артефакта) и `APP_DISPLAY_NAME` (то, что видит пользователь). На macOS `--name` берёт второе, на Windows/Linux — первое, так что имена скачиваемых файлов не меняются;
- `QApplication.setApplicationName / setApplicationDisplayName / setDesktopFileName`. На Linux Qt строит WM_CLASS из `argv[0]`, поэтому таскбар подписывал окно `trainings-sync-linux-x86_64`;
- заголовок окна теперь берётся из той же константы, а не из отдельного литерала.

## Коммит 2 — идентификатор и версия

- `--osx-bundle-identifier io.github.dchernykh1984.trainings-sync`;
- `CFBundleShortVersionString` и `CFBundleVersion` проставляются из тега релиза (на smoke-сборке — из `pyproject.toml`).

PyInstaller подписывает бандл ad-hoc, и правка plist эту подпись ломает (`plist or signature have been modified`), поэтому после `plutil` идёт `codesign --force --sign -`.

## Проверка

Собрал бандл локально ровно теми же командами:

- plist: `CFBundleName` / `CFBundleDisplayName` = `Trainings Sync`, идентификатор reverse-DNS, версия `0.2.0`;
- `codesign --verify --deep --strict` — валидна, в том числе после zip round-trip;
- полный набор тестов зелёный.

Тесты прибивают workflow к коду: `tests/gui/test_build_workflow.py` падает, если `APP_DISPLAY_NAME` в workflow разъедется с константой в приложении или если bundle id перестанет соответствовать имени проекта. Именно этот шов и разошёлся незамеченным.

## На что обратить внимание

Смена `CFBundleIdentifier` — для macOS это другое приложение. Разрешения, выданные старой сборке (доступ к папкам, уведомления), придётся выдать заново при первом запуске.

Не затронуто: у Windows-сборки по-прежнему нет ресурса VERSIONINFO, поэтому в диспетчере задач видно имя exe-файла. На таскбар и Alt-Tab это не влияет — там показывается заголовок окна.