### PR TITLE
fix: keep the macos bundle file name free of spaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,13 @@ env:
   # File name: the artifacts and the frozen executable. Kept ASCII and
   # space-free so a download URL stays readable.
   APP_NAME: trainings-sync
-  # User-facing name. macOS reads it from the bundle for the dock, the task
-  # switcher and the menu bar - none of which ever look at the window title,
-  # so leaving it as APP_NAME showed the app as "trainings-sync".
-  APP_DISPLAY_NAME: Trainings Sync
+  # Name of the .app bundle. macOS shows the bundle's *file name* in the dock
+  # and the task switcher; CFBundleName and CFBundleDisplayName are ignored
+  # for apps outside /Applications, even with LSHasLocalizedDisplayName and a
+  # localized InfoPlist.strings (all three were tried). So the dock name and
+  # the file name are one and the same setting, and this one stays space-free
+  # because the bundle is a file users copy around.
+  APP_BUNDLE_NAME: TrainingsSync
   # Reverse-DNS bundle id. macOS keys preferences, granted folder permissions
   # and LaunchServices registration off this, so every app needs its own.
   APP_BUNDLE_ID: io.github.dchernykh1984.trainings-sync
@@ -79,10 +82,10 @@ jobs:
           pyi=(uv run --with "pyinstaller>=6,<7" pyinstaller)
           common=(--noconfirm --windowed --collect-submodules app)
           if [ "$RUNNER_OS" = "macOS" ]; then
-            # --name drives every name in the bundle's Info.plist, so the
-            # bundle carries the display name while the zip around it keeps
-            # the artifact name.
-            "${pyi[@]}" --name "$APP_DISPLAY_NAME" --icon app/app.icns \
+            # --name sets the .app folder name, which is what the dock shows.
+            # The zip around it keeps the artifact name, so download URLs are
+            # unaffected.
+            "${pyi[@]}" --name "$APP_BUNDLE_NAME" --icon app/app.icns \
               --osx-bundle-identifier "$APP_BUNDLE_ID" \
               "${common[@]}" app/gui/app.py
             # PyInstaller hardcodes CFBundleShortVersionString to 0.0.0 and
@@ -93,14 +96,14 @@ jobs:
             if [ -z "$version" ]; then
               version=$(awk -F'"' '/^version *= *"/ {print $2; exit}' pyproject.toml)
             fi
-            plist="dist/${APP_DISPLAY_NAME}.app/Contents/Info.plist"
+            plist="dist/${APP_BUNDLE_NAME}.app/Contents/Info.plist"
             plutil -replace CFBundleShortVersionString -string "$version" "$plist"
             plutil -replace CFBundleVersion -string "$version" "$plist"
             # Editing the plist breaks the ad-hoc signature PyInstaller
             # applied ("plist or signature have been modified"), so reseal it.
-            codesign --force --sign - "dist/${APP_DISPLAY_NAME}.app"
+            codesign --force --sign - "dist/${APP_BUNDLE_NAME}.app"
             ( cd dist && zip -r -y "${APP_NAME}-${{ matrix.name }}.zip" \
-              "${APP_DISPLAY_NAME}.app" )
+              "${APP_BUNDLE_NAME}.app" )
             echo "ASSET=dist/${APP_NAME}-${{ matrix.name }}.zip" >> "$GITHUB_ENV"
           elif [ "$RUNNER_OS" = "Windows" ]; then
             "${pyi[@]}" --name "$APP_NAME" --onefile --icon app/app.ico \

--- a/tests/gui/test_build_workflow.py
+++ b/tests/gui/test_build_workflow.py
@@ -30,8 +30,17 @@ def _project_name() -> str:
     return match.group(1)
 
 
-def test_workflow_display_name_matches_the_app() -> None:
-    assert _workflow_env("APP_DISPLAY_NAME") == APP_DISPLAY_NAME
+def test_workflow_bundle_name_matches_the_app() -> None:
+    # macOS shows the .app folder name in the dock and ignores the plist's
+    # CFBundleName/CFBundleDisplayName, so the bundle name *is* the dock name.
+    # It has to stay space-free, hence the display name with spaces removed.
+    assert _workflow_env("APP_BUNDLE_NAME") == APP_DISPLAY_NAME.replace(" ", "")
+
+
+def test_workflow_bundle_name_has_no_spaces() -> None:
+    # The bundle is a file people copy between folders; spaces in it make
+    # every shell command that touches it need quoting.
+    assert " " not in _workflow_env("APP_BUNDLE_NAME")
 
 
 def test_workflow_bundle_id_is_reverse_dns_for_this_project() -> None:


### PR DESCRIPTION
## Проблема

Прошлый фикс сделал `.app` с пробелами — `Trainings Sync.app`. В Dock стало правильно, но файл, который вы копируете между папками, теперь требует кавычек в любой команде оболочки. Имя файла важнее.

## Можно ли получить и то, и другое

Нет. Проверил экспериментально три документированных способа развести имя в Dock и имя папки:

| Что пробовал | Что показал macOS |
|---|---|
| `CFBundleName` + `CFBundleDisplayName` в plist | имя папки |
| то же + локализованный `Contents/Resources/en.lproj/InfoPlist.strings` | имя папки |
| то же + `LSHasLocalizedDisplayName` + `CFBundleDevelopmentRegion` | имя папки |

Обратная проверка закрепила вывод: папка `Spaced Folder Name.app` с plist-именем `nospacename` дала в LaunchServices `LSDisplayName="Spaced Folder Name"`.

Для приложений вне `/Applications` **имя в Dock и Cmd-Tab — это имя папки `.app`**, а ключи plist игнорируются. Так что выбор бинарный, и выигрывает имя файла.

## Что сделано

`APP_DISPLAY_NAME: Trainings Sync` в workflow заменён на `APP_BUNDLE_NAME: TrainingsSync`. В Dock будет `TrainingsSync` — без пробелов, но и не `trainings-sync`, на который вы жаловались изначально. Это ровно та форма, в которой уже показываются четыре ваших других приложения (`StartProtocolMaker`, `FinishProtocolGenerator`).

Не изменилось:

- имена скачиваемых файлов — `trainings-sync-macos-arm64.zip` и остальные четыре платформы как были. Windows и Linux всегда собирались с `--name "$APP_NAME"`, их этот фикс не касается;
- заголовок окна — по-прежнему `Trainings Sync` с пробелом, он берётся из `APP_DISPLAY_NAME` в коде приложения;
- имя приложения для Qt и WM_CLASS на Linux;
- bundle id и версия в plist.

## Тесты

`test_workflow_bundle_name_matches_the_app` теперь связывает `APP_BUNDLE_NAME` с `APP_DISPLAY_NAME` из кода по правилу «то же самое без пробелов» — то есть переименование на одной стороне всё так же ломает сборку, а не уезжает молча. Добавлен `test_workflow_bundle_name_has_no_spaces`, который не даст пробелам вернуться.

## При установке

Папка приложения меняет имя, так что старый `Trainings Sync.app` придётся удалить вручную — сам он не исчезнет. Конфиги не затронуты: они лежат рядом с бандлом, а не внутри него.